### PR TITLE
update nested_inputs so off-grid defaults do not incorrectly appear f…

### DIFF
--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -133,6 +133,29 @@ off_grid_defaults = {
           "type": "bool",
           "default": False,
           "description": "Boolean value for if outage is a major event, which affects the avoided_outage_costs_us_dollars. If True, the avoided outage costs are calculated for a single outage occurring in the first year of the analysis_years. If False, the outage event is assumed to be an average outage event that occurs every year of the analysis period. In the latter case, the avoided outage costs for one year are escalated and discounted using the escalation_pct and offtaker_discount_pct to account for an annually recurring outage. (Average outage durations for certain utility service areas can be estimated using statistics reported on EIA form 861.)"
+        },
+        "sr_required_pct": {
+          "type": "float",
+          "min": 0.0,
+          "max": 1.0,
+          "default": 0.1,
+          "description": "Applies to off-grid scenarios only. Spinning reserve requirement for changes in load in off-grid analyses. Value must be between zero and one, inclusive."
+        },
+        "min_load_met_pct": {
+          "type": "float",
+          "min": 0.0,
+          "max": 1.0,
+          "default": 0.999,
+          "description": "Applies to off-grid scenarios only. Fraction of the load that must be met on an annual energy basis. Value must be between zero and one, inclusive."
+        }
+      },
+      "PV": {
+        "sr_required_pct": {
+          "type": "float",
+          "min": 0.0,
+          "max": 1.0,
+          "default": 0.25,
+          "description": "Applies to off-grid scenarios only. Spinning reserve requirement for PV serving load in off-grid analyses. Value must be between zero and one, inclusive."
         }
       },
       "Storage": {
@@ -170,7 +193,7 @@ off_grid_defaults = {
         },
         "useful_life_years": {
           "type": "float", "min": 0.0, "max": max_years, "default": 10,
-          "description": "Number of years asset can be used for before replacement. A single replacement is considered for off-grid generators."
+          "description": "Applies to off-grid scenarios only. Number of years asset can be used for before replacement. A single replacement is considered for off-grid generators."
         }
       }
     }
@@ -591,15 +614,15 @@ nested_input_definitions = {
           "type": "float",
           "min": 0.0,
           "max": 1.0,
-          "default": 0.999,
-          "description": "Fraction of the load that must be met on an annual energy basis. Value must be between zero and one, inclusive."
+          "default": 1.0,
+          "description": "Applies to off-grid scenarios only. Fraction of the load that must be met on an annual energy basis. Value must be between zero and one, inclusive."
         },
         "sr_required_pct": {
           "type": "float",
           "min": 0.0,
           "max": 1.0,
-          "default": 0.1,
-          "description": "Spinning reserve requirement for changes in load in off-grid analyses. Value must be between zero and one, inclusive."
+          "default": 0.0,
+          "description": "Applies to off-grid scenarios only. Spinning reserve requirement for changes in load in off-grid analyses. Value must be between zero and one, inclusive."
         }
       },
 
@@ -1384,8 +1407,8 @@ nested_input_definitions = {
           "type": "float",
           "min": 0.0,
           "max": 1.0,
-          "default": 0.25,
-          "description": "Spinning reserve requirement for PV serving load in off-grid analyses. Value must be between zero and one, inclusive."
+          "default": 0.0,
+          "description": "Applies to off-grid scenarios only. Spinning reserve requirement for PV serving load in off-grid analyses. Value must be between zero and one, inclusive."
         }
       },
 

--- a/reo/tests/test_offgrid.py
+++ b/reo/tests/test_offgrid.py
@@ -71,13 +71,13 @@ class TestOffGridSystem(ResourceTestCaseMixin, TestCase):
                     "annual_kwh": 87600.0,
                     "year": 2017,
                     "min_load_met_pct": 1.0,
-                    "sr_required_pct": 0.1
+                    # "sr_required_pct": 0.1
                   },
                   "PV": {
                     "existing_kw": 0.0,
                     "min_kw": 0.0,
                     "max_kw": 1.0e5,
-                    "sr_required_pct": 0.25,
+                    # "sr_required_pct": 0.25,
                     "installed_cost_us_dollars_per_kw": 1600.0,
                     "om_cost_us_dollars_per_kw": 16.0,
                     "macrs_option_years": 0,


### PR DESCRIPTION
Previously, the off-grid defaults for sr_required_pct and min_load_met_pct would appear in the inputs nested dict returned from posting to the API, even for on-grid runs. However, these defaults do not get applied to on-grid runs, so this is likely to mislead users. Now, the default for min_load_met will show as 1.0 and sr_required (for load and PV) will show as 0 for on-grid runs. The applicability of these inputs to off-grid is also now specified in the descriptions.

### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Adds PV | `sr_required_pct` and LoadProfile | `sr_required_pct`, and LoadProfile | `min_load_met_pct` to the off_grid_defaults nested dict in nested_inputs.py. This allows for distinct defaults to be supplied for off- and on-grid runs. 

### What is the current behavior?
(You can also link to an open issue here)
Currently, if a user does an on-grid analysis, they will see off-grid spinning reserve and min_load_met defaults in the inputs key of the returned nested dictionary. This is likely to be confusing, as the defaults don't actually get applied in on-grid runs. 

### What is the new behavior (if this is a feature change)?
The default for min_load_met will show as 1.0 and sr_required (for load and PV) will show as 0 for on-grid runs. The applicability of these inputs to off-grid is also now specified in the descriptions.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No. 

