### PR TITLE
Fix validator bug where list_of_list conversion didn't capture inner list type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,20 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop - 2022-03-08
+### Patches
+- `reo`: Fix list_of_list conversion in `validators.py` not capturing inner list type. E.g. a 2D list of floats that was supposed to be a 2D list of integers wasn't getting caught.
+
 ## v1.9.1 - 2021-12-16
 ### Minor Updates
 ##### Added
-- `reo`: `GHP` heating and cooling HVAC efficiency thermal factor inputs and defaults to account for a reduction in heating and/or cooling loads with GHP retrofits
-- `*.jl`: Reduction in heating and cooling loads due to the thermal factors (described above) if `GHP` is chosen.  
+- `reo`: **GHP** heating and cooling HVAC efficiency thermal factor inputs and defaults to account for a reduction in heating and/or cooling loads with **GHP** retrofits
+- `*.jl`: Reduction in heating and cooling loads due to the thermal factors (described above) if **GHP** is chosen.  
 
 ## v1.9.0 - 2021-12-15
 ### Minor Updates
 ##### Added
-- `reo`: Added capability to estimate year 1 and lifecycle emissions and climate and health costs of CO2, NOx, SO2, and PM2.5 from on-site fuel burn and grid-purchased electricity. Added total renewable energy calculations. User options to include climate and/or health costs in the objective function. User options to set emissions and/or renewable electricity constraints. User options to include or exclude exported electricity in renewable energy and emissions calculations. New emissions and renewable energy inputs (and defaults) in `nested_inputs.py` and outputs in `nested_outputs.py`. Added default emissions data for NOx, PM2.5, and SO2 in `src/data`. Default marginal health costs in `src/data/EASIUR_Data`. In `views.py` and `urls.py` added `easiur_costs` and `fuel_emissions_rates` urls. Default fuel emissions rates for NOx, SO2, and PM2.5 in `validators.py`. Added calculation of breakeven CO2 cost (when NPV is negative).
+- `reo`: Added capability to estimate year 1 and lifecycle emissions and climate and health costs of CO2, NOx, SO2, and PM2.5 from on-site fuel burn and grid-purchased electricity. Added total renewable energy calculations. User options to include climate and/or health costs in the objective function. User options to set emissions and/or renewable electricity constraints. User options to include or exclude exported electricity in renewable energy and emissions calculations. New emissions and renewable energy inputs (and defaults) in `nested_inputs.py` and outputs in `nested_outputs.py`. Added default emissions data for NOx, PM2.5, and SO2 in `src/data`. Default marginal health costs in `src/data/EASIUR_Data`. In `views.py` and `urls.py` added **easiur_costs** and **fuel_emissions_rates** urls. Default fuel emissions rates for NOx, SO2, and PM2.5 in `validators.py`. Added calculation of breakeven CO2 cost (when NPV is negative).
 - `reopt_model.jl`: Included additional optional constraints for emissions reductions (as compared to BAU) and renewable electricity percentage. Added optional inclusion of climate and health costs to the model objective and associated life cycle cost calculation. Added calculations of life cycle emissions and costs for CO2, NOx, SO2, and PM2.5. Added calculation of renewable energy (% and kWh), which includes electric and thermal end uses. Emissions and renewable energy calculations account for all technologies.   
 - `utils.jl` added emissions- and renewable energy-specific parameters.
 ##### Changed 

--- a/reo/models.py
+++ b/reo/models.py
@@ -410,7 +410,7 @@ class ElectricTariffModel(models.Model):
     chp_standby_rate_us_dollars_per_kw_per_month = models.FloatField(blank=True, null=True)
     chp_does_not_reduce_demand_charges = models.BooleanField(null=True, blank=True)
     emissions_region = models.TextField(null=True, blank=True)
-    coincident_peak_load_active_timesteps = ArrayField(ArrayField(models.FloatField(null=True, blank=True), null=True, default=list), null=True, default=list)
+    coincident_peak_load_active_timesteps = ArrayField(ArrayField(models.IntegerField(null=True, blank=True), null=True, default=list), null=True, default=list)
     coincident_peak_load_charge_us_dollars_per_kw = ArrayField(models.FloatField(null=True, blank=True), null=True, default=list)
     emissions_factor_CO2_pct_decrease = models.FloatField(null=True, blank=True)
     emissions_factor_NOx_pct_decrease = models.FloatField(null=True, blank=True)

--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -85,8 +85,8 @@ def list_of_float(input):
 def list_of_str(input):
   return [str(i) for i in input]
 
-def list_of_list(input):
-  return [list(i) for i in input]
+def list_of_list(input, inner_list_conversion_function=list):
+  return [inner_list_conversion_function(i) for i in input]
 
 def list_of_int(input):
   result = []

--- a/reo/tests/test_coincident_peak.py
+++ b/reo/tests/test_coincident_peak.py
@@ -75,7 +75,7 @@ class TestCoincidentPeak(ResourceTestCaseMixin, TestCase):
                         "doe_reference_name": "MidriseApartment"
                     },
                     "ElectricTariff": {
-                        "coincident_peak_load_active_timesteps": [[1.0,2.0,100.0],[6000.0,7000.0]],
+                        "coincident_peak_load_active_timesteps": [[1,2.0,100.0],[6000.0,7000.0]],
                         "coincident_peak_load_charge_us_dollars_per_kw": [10,5],
                         "add_blended_rates_to_urdb_rate": False,
                         "net_metering_limit_kw": 0,

--- a/reo/tests/test_coincident_peak.py
+++ b/reo/tests/test_coincident_peak.py
@@ -75,7 +75,7 @@ class TestCoincidentPeak(ResourceTestCaseMixin, TestCase):
                         "doe_reference_name": "MidriseApartment"
                     },
                     "ElectricTariff": {
-                        "coincident_peak_load_active_timesteps": [[1,2,100],[6000,7000]],
+                        "coincident_peak_load_active_timesteps": [[1.0,2.0,100.0],[6000.0,7000.0]],
                         "coincident_peak_load_charge_us_dollars_per_kw": [10,5],
                         "add_blended_rates_to_urdb_rate": False,
                         "net_metering_limit_kw": 0,

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -2101,20 +2101,21 @@ class ValidateNestedInput:
                                 except:
                                     isValidAlternative = False
                                     for alternate_data_type in attribute_type:
-                                        try:
-                                            new_value = eval(alternate_data_type)(value)
-                                            attribute_type = alternate_data_type
-                                            make_array = True
-                                            # In case where the data is not at least a list (i.e. int), make it a list
-                                            # so it will later be made into a list of lists
-                                            if not isinstance(new_value, list):
-                                                make_array_of_array = True
-                                                new_value = new_value
-                                                self.update_attribute_value(object_name_path, number, name, new_value)
-                                            isValidAlternative = True
-                                            break
-                                        except:
-                                            pass
+                                        if alternate_data_type != "list_of_list":
+                                            try:
+                                                new_value = eval(alternate_data_type)(value)
+                                                attribute_type = alternate_data_type
+                                                make_array = True
+                                                # In case where the data is not at least a list (i.e. int), make it a list
+                                                # so it will later be made into a list of lists
+                                                if not isinstance(new_value, list):
+                                                    make_array_of_array = True
+                                                    new_value = new_value
+                                                    self.update_attribute_value(object_name_path, number, name, new_value)
+                                                isValidAlternative = True
+                                                break
+                                            except:
+                                                pass
                                     if isValidAlternative == False:
                                         if input_isDict or input_isDict is None:
                                             self.input_data_errors.append('Could not convert %s (%s) in %s to one of %s' % (

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -2018,12 +2018,15 @@ class ValidateNestedInput:
         :return: None
         """
 
-        def test_conversion(conversion_function, conversion_function_name, name, value, object_name_path, number, input_isDict, record_errors=True):
+        def test_conversion(conversion_function, conversion_function_name, name, value, object_name_path, number, input_isDict, record_errors=True, list_of_list_inner_conversion_function=None):
             try:
                 series = pd.Series(value)
                 if series.isnull().values.any():
                     raise NotImplementedError
-                new_value = conversion_function(value)
+                if list_of_list_inner_conversion_function == None:
+                    new_value = conversion_function(value)
+                else:
+                    new_value = conversion_function(value, inner_list_conversion_function = list_of_list_inner_conversion_function)
             except ValueError:
                 if record_errors:
                     if input_isDict or input_isDict is None:
@@ -2094,7 +2097,7 @@ class ValidateNestedInput:
                                 # Finally if it is a valid alternate type we set it to be converted to a list at the end
                                 # otherwise we flag an error
                                 try:
-                                    new_value = test_conversion(list_of_list, "list of list", name, value, object_name_path, number, input_isDict, record_errors=False)
+                                    new_value = test_conversion(list_of_list, "list of list", name, value, object_name_path, number, input_isDict, record_errors=False, list_of_list_inner_conversion_function=eval(list_eval_function_name))
                                 except:
                                     isValidAlternative = False
                                     for alternate_data_type in attribute_type:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
bug fix


### What is the current behavior?
(You can also link to an open issue here)
When a 2D list was provided for coincident_peak_load_active_timesteps, and it had float values in it that were invalid time steps (e.g 1.2), the validator would not return an error. In the JuMP model, the floats would be used as indices and result in a REoptFailedToStart error for the user. When a 2D list provided had float values but they were integers in float form (e.g. 1.0), the validator would not convert these to integers, resulting also in a REoptFailedToStart error.


### What is the new behavior (if this is a feature change)?
Any time float values are provided in coincident_peak_load_active_timesteps, the validator converts them to integers if possible otherwise gives the input error "Could not convert coincident_peak_load_active_timesteps (<value>) in Scenario>Site>ElectricTariff to one of int,list_of_int,list_of_list"


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
no


### Other information:
