### PR TITLE
Fix outage time step inconsistencies and incorrect validation

### DIFF
--- a/job/models.py
+++ b/job/models.py
@@ -1048,7 +1048,7 @@ class ElectricUtilityInputs(BaseModel, models.Model):
             MinValueValidator(1)
             # max value validated in InputValidator b/c it requires Settings.time_steps_per_hour
         ],
-        help_text="Time step that grid outage starts. Must be less than outage_end."
+        help_text="Time step that grid outage starts. Must be less than or equal to outage_end_time_step."
     )
     outage_end_time_step = models.IntegerField(
         null=True,
@@ -1057,7 +1057,7 @@ class ElectricUtilityInputs(BaseModel, models.Model):
             MinValueValidator(1)
             # max value validated in InputValidator b/c it requires Settings.time_steps_per_hour
         ],
-        help_text="Time step that grid outage ends. Must be greater than outage_start."
+        help_text="Time step that grid outage ends. Must be greater than or equal to outage_start_time_step."
     )
     interconnection_limit_kw = models.FloatField(
         validators=[

--- a/job/models.py
+++ b/job/models.py
@@ -1089,10 +1089,9 @@ class ElectricUtilityInputs(BaseModel, models.Model):
             error_messages["outage_start_time_step"] = "Got outage_end_time_step but no outage_start_time_step."
 
         if self.outage_start_time_step is not None and self.outage_end_time_step is not None:
-            if self.outage_start_time_step >= self.outage_end_time_step:
+            if self.outage_start_time_step > self.outage_end_time_step:
                 error_messages["outage start/stop time steps"] = \
-                    ('outage_end_time_step must be larger than outage_start_time_step and these inputs '
-                     'cannot be equal.')
+                    ('outage_end_time_step must be larger than or equal to outage_start_time_step.')
 
         if error_messages:
             raise ValidationError(error_messages)

--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -575,28 +575,28 @@ nested_input_definitions = {
           "min": 0,
           "max": 8759,
           "depends_on": ["outage_end_hour"],
-          "description": "Hour of year that grid outage starts. Must be less than outage_end."
+          "description": "Hour of year that grid outage starts. Must be less than or equal to outage_end_hour."
         },
         "outage_end_hour": {
           "type": "int",
           "min": 0,
           "max": 8759,
           "depends_on": ["outage_start_hour"],
-          "description": "Hour of year that grid outage ends. Must be greater than outage_start."
+          "description": "Hour of year that grid outage ends. Must be greater than or equal to outage_start_hour."
         },
         "outage_start_time_step": {
           "type": "int",
           "min": 1,
           "max": 35040,
           "depends_on": ["outage_end_time_step"],
-          "description": "Time step that grid outage starts. Must be less than outage_end."
+          "description": "Time step that grid outage starts. Must be less than or equal to outage_end_time_step."
         },
         "outage_end_time_step": {
           "type": "int",
           "min": 1,
           "max": 35040,
           "depends_on": ["outage_start_time_step"],
-          "description": "Time step that grid outage ends. Must be greater than outage_start."
+          "description": "Time step that grid outage ends. Must be greater than or equal to outage_start_time_step."
         },
         "critical_load_pct": {
           "type": "float",

--- a/reo/src/data_manager.py
+++ b/reo/src/data_manager.py
@@ -1137,7 +1137,7 @@ class DataManager:
             bau_grid_to_load_kw -= np.array([pv.existing_kw * x * levelization_factor for x in pv.prod_factor])
 
         #No grid emissions, or pv exporting to grid, during an outage
-        for i in range((self.load.outage_start_time_step or 1) -1, (self.load.outage_end_time_step or 1) -1):
+        for i in range((self.load.outage_start_time_step or 1) -1, (self.load.outage_end_time_step or 0)):
             bau_grid_to_load_kw[i] = 0
 
         #If no net emissions accounting, no credit for RE grid exports:

--- a/reo/tests/test_chp.py
+++ b/reo/tests/test_chp.py
@@ -209,10 +209,10 @@ class CHPTest(ResourceTestCaseMixin, TestCase):
 
         # The values compared to the expected values
         #self.assertTrue(all(chp_to_load[i] == tot_elec_load[i] for i in range(outage_start, outage_end)))
-        self.assertAlmostEqual(sum(chp_to_load[outage_start-1:outage_end-1]),sum(tot_elec_load[outage_start-1:outage_end-1]), places=1)
+        self.assertAlmostEqual(sum(chp_to_load[outage_start-1:outage_end]),sum(tot_elec_load[outage_start-1:outage_end]), places=1)
         self.assertEqual(sum(chp_export), 0.0)  # Resulting in "None" instead of zero - likely because ExportTiers is empty
         self.assertAlmostEqual(sum(chp_total_elec_prod), sum(chp_to_load), delta=1.0E-5*sum(chp_total_elec_prod))
-        self.assertEqual(sum(cooling_elec_load[outage_start-1:outage_end-1]), 0.0) 
+        self.assertEqual(sum(cooling_elec_load[outage_start-1:outage_end]), 0.0) 
         self.assertEqual(sum(chp_total_elec_prod[unavail_2_start-1:unavail_2_end-1]), 0.0)
 
     def test_supplementary_firing(self):

--- a/reo/tests/test_diesel_gen_sizing.py
+++ b/reo/tests/test_diesel_gen_sizing.py
@@ -59,7 +59,7 @@ class GeneratorSizingTests(ResourceTestCaseMixin, TestCase):
         tech_to_load = list()
         for tech in list_to_load:
             if tech is not None:
-                tech_to_load = [sum_t + t for sum_t, t in zip(tech_to_load, tech[outage_start:outage_end])]
+                tech_to_load = [sum_t + t for sum_t, t in zip(tech_to_load, tech[outage_start-1:outage_end])]
         return tech_to_load
 
     def test_generator_sizing_with_existing_pv(self):
@@ -123,5 +123,5 @@ class GeneratorSizingTests(ResourceTestCaseMixin, TestCase):
 
         list_to_load = [generator_to_load, storage_to_load, pv_to_load]
         tech_to_load = self.outage_tech_to_load(list_to_load, outage_start, outage_end)
-        for x, y in zip(critical_load[outage_start:outage_end], tech_to_load):
+        for x, y in zip(critical_load[outage_start-1:outage_end], tech_to_load):
             self.assertAlmostEquals(x, y, places=3)

--- a/reo/tests/test_reopt_url.py
+++ b/reo/tests/test_reopt_url.py
@@ -142,7 +142,7 @@ class EntryResourceTest(ResourceTestCaseMixin, TestCase):
         response = self.get_response(data)
         err_msg = str(json.loads(response.content)['messages']['input_errors'])
 
-        self.assertTrue("LoadProfile outage_end_time_step must be larger than outage_start_time_step" in err_msg)
+        self.assertTrue("LoadProfile outage_start_time_step must be less than or equal to outage_end_time_step." in err_msg)
 
     def test_valid_data_ranges(self):
 

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -997,14 +997,6 @@ class ValidateNestedInput:
                         self.input_data_errors.append(
                             'min_kwh (%s) in %s is larger than the max_kwh value (%s)' % ( real_values.get('min_kwh'), self.object_name_string(object_name_path), real_values.get('max_kwh'))
                             )
-                if object_name_path[-1] in ['LoadProfile']:
-                    if real_values.get('outage_start_hour') is not None and real_values.get('outage_end_hour') is not None:
-                        if real_values.get('outage_start_hour') >= real_values.get('outage_end_hour'):
-                            self.input_data_errors.append('LoadProfile outage_end_hour must be larger than outage_end_hour and these inputs cannot be equal')
-
-                    if real_values.get('outage_start_time_step') is not None and real_values.get('outage_end_time_step') is not None:
-                        if real_values.get('outage_start_time_step') > real_values.get('outage_end_time_step'):
-                            self.input_data_errors.append('LoadProfile outage_end_time_step must be larger than outage_start_time_step.')
 
     def check_for_nans(self, object_name_path, template_values=None, real_values=None, number=1, input_isDict=None):
         """
@@ -1312,8 +1304,8 @@ class ValidateNestedInput:
         if object_name_path[-1] == "LoadProfile":
             if self.isValid:
                 if real_values.get('outage_start_time_step') is not None and real_values.get('outage_end_time_step') is not None:
-                    if real_values.get('outage_start_time_step') >= real_values.get('outage_end_time_step'):
-                        self.input_data_errors.append('LoadProfile outage_start_time_step must be less than outage_end_time_step.')
+                    if real_values.get('outage_start_time_step') > real_values.get('outage_end_time_step'):
+                        self.input_data_errors.append('LoadProfile outage_start_time_step must be less than or equal to outage_end_time_step.')
                     if self.input_dict['Scenario']['time_steps_per_hour'] == 1 and real_values.get('outage_end_time_step') > 8760:
                         self.input_data_errors.append('outage_end_time_step must be <= 8760 when time_steps_per_hour = 1')
                     if self.input_dict['Scenario']['time_steps_per_hour'] == 2 and real_values.get('outage_end_time_step') > 17520:
@@ -1321,6 +1313,8 @@ class ValidateNestedInput:
                     # case of 'time_steps_per_hour' == 4 and outage_end_time_step > 35040 handled by "max" value
 
                 if real_values.get('outage_start_hour') is not None and real_values.get('outage_end_hour') is not None:
+                    if real_values.get('outage_start_hour') > real_values.get('outage_end_hour'):
+                        self.input_data_errors.append('LoadProfile outage_start_hour must be less than or equal to outage_end_hour.')
                     # the following preserves the original behavior
                     self.update_attribute_value(object_name_path, number, 'outage_start_time_step',
                                                 real_values.get('outage_start_hour') + 1)
@@ -1348,9 +1342,6 @@ class ValidateNestedInput:
                         self.input_data_errors.append((
                             'The length of doe_reference_name and percent_share lists should be equal'
                             ' for constructing hybrid LoadProfile'))
-                if real_values.get('outage_start_hour') is not None and real_values.get('outage_end_hour') is not None:
-                    if real_values.get('outage_start_hour') == real_values.get('outage_end_hour'):
-                        self.input_data_errors.append('LoadProfile outage_start_hour and outage_end_hour cannot be the same')
                 for lp in ['critical_loads_kw', 'loads_kw']:
                     if real_values.get(lp) not in [None, []]:
                         self.validate_8760(real_values.get(lp), "LoadProfile", lp, self.input_dict['Scenario']['time_steps_per_hour'],


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
bug fix


### What is the current behavior?
(You can also link to an open issue here)
Outage modeled is outage_start_time_step to outage_end_time_step (or outage_start_hour+1 to outage_end_hour+1)  _inclusive_, but the reo and job validators don't allow start and end to be equal, thus making a 1 time step outage impossible to model. In the BAU emissions calculation, when setting emissions to zero during the outage, outage_end_time_step is skipped. In the generator sizing test, when checking if the sum of tech energy to load equals critical load in each outage time step, outage_start_time_step is not included.


### What is the new behavior (if this is a feature change)?
The reo and job validators both allow outage start and end to be equal. In the BAU emissions calculation, emissions are set to zero in all outage time steps. The generator sizing test checks if the sum of tech energy to load equals critical load in all outage time steps.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
no


### Other information:
