### PR TITLE
correct CHP O&M cost per hr per kw bug

### DIFF
--- a/reo/src/data_manager.py
+++ b/reo/src/data_manager.py
@@ -862,7 +862,7 @@ class DataManager:
                     tech_emissions_factors_PM25.append(float(eval('self.' + tech + '.emissions_factor_lb_PM25_per_gal') / GAL_DIESEL_TO_KWH))
                 elif tech.lower() == 'chp':
                     om_cost_us_dollars_per_kwh.append(float(eval('self.' + tech + '.om_cost_us_dollars_per_kwh')))
-                    om_cost_us_dollars_per_hr_per_kw_rated.append(float(eval('self.' + tech + '.om_cost_us_dollars_per_hr_per_kw_rated') / MMBTU_TO_KWH))
+                    om_cost_us_dollars_per_hr_per_kw_rated.append(float(eval('self.' + tech + '.om_cost_us_dollars_per_hr_per_kw_rated')))
                     tech_percent_RE.append(float(eval('self.fuel_tariff.chp_fuel_percent_RE')))
                     tech_emissions_factors_CO2.append(float(eval('self.' + tech + '.emissions_factor_lb_CO2_per_mmbtu') / MMBTU_TO_KWH))
                     tech_emissions_factors_NOx.append(float(eval('self.' + tech + '.emissions_factor_lb_NOx_per_mmbtu') / MMBTU_TO_KWH))


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
bug fix


### What is the current behavior?
(You can also link to an open issue here)
Units of CHP om_cost_us_dollars_per_hr_per_kw_rated are incorrectly converted when it's already the correct units


### What is the new behavior (if this is a feature change)?
the CHP O&M om_cost_us_dollars_per_hr_per_kw_rated given to the optimization model is in units of dollars per hr per kw


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
no


### Other information:
