### PR TITLE
Update nested_inputs.py

### DIFF
--- a/reo/nested_inputs.py
+++ b/reo/nested_inputs.py
@@ -433,7 +433,7 @@ nested_input_definitions = {
         "other_capital_costs_us_dollars": {
           "type": "float",
           "min": 0.0,
-          "max": max_big_number,
+          "max": 1.0e10,
           "default": 0,
           "description": "Other capital costs associated with the distributed energy system project. These can include land purchase costs, distribution network costs, powerhouse or battery container structure costs, and pre-operating expenses. These costs will be incorporated in the life cycle cost and levelized cost of electricity calculations."
         },


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ N/A] Tests for the changes have been added (for bug fixes / features)
- [ N/A] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Increases the max value of `other_capital_costs_us_dollars` to 1.0e10 in `nested_inputs.py`. 



### What is the current behavior?
(You can also link to an open issue here)
Was set to max_big_number (1.0e8).


### What is the new behavior (if this is a feature change)?
Set to 1.0e10


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No.


### Other information:
I am running off-grid microgrid analyses for Kenya, and some of the capital costs exceed the current upper bound. 
