### PR TITLE
remove override of fuel_slope and fuel_intercept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+# "Develop - 2022-04-22"
 
+### Minor Updates
+##### Changed
+Removed override of user inputs for `fuel_slope_gal_per_kwh` and `fuel_intercept_gal_per_hr` in validators.py. User inputs for these values will now be used in analysis. If these inputs are not supplied, the default values in nested_inputs.py will be used.
 # v2.0.0 Default cost updates
 Changing default costs can result in different results for the same inputs. Hence we are making a major version change.
 

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1295,15 +1295,15 @@ class ValidateNestedInput:
                 if self.input_dict['Scenario']['Site']['Generator'].get('emissions_factor_lb_PM25_per_gal') is None:
                     self.update_attribute_value(object_name_path, number, 'emissions_factor_lb_PM25_per_gal', self.fuel_conversion_lb_PM25_per_gal.get('diesel_oil'))
                 
-                if (real_values["max_kw"] > 0 or real_values["existing_kw"] > 0):
-                    # then replace zeros in default burn rate and slope, and set min/max kw values appropriately for
-                    # REopt (which need to be in place before data is saved and passed on to celery tasks)
-                    gen = real_values
-                    m, b = Generator.default_fuel_burn_rate(gen["min_kw"] + gen["existing_kw"])
-                    if gen["fuel_slope_gal_per_kwh"] == 0:
-                        gen["fuel_slope_gal_per_kwh"] = m
-                    if gen["fuel_intercept_gal_per_hr"] == 0:
-                        gen["fuel_intercept_gal_per_hr"] = b
+                # if (real_values["max_kw"] > 0 or real_values["existing_kw"] > 0):
+                #     # then replace zeros in default burn rate and slope, and set min/max kw values appropriately for
+                #     # REopt (which need to be in place before data is saved and passed on to celery tasks)
+                #     gen = real_values
+                #     m, b = Generator.default_fuel_burn_rate(gen["min_kw"] + gen["existing_kw"])
+                #     if gen["fuel_slope_gal_per_kwh"] == 0:
+                #         gen["fuel_slope_gal_per_kwh"] = m
+                #     if gen["fuel_intercept_gal_per_hr"] == 0:
+                #         gen["fuel_intercept_gal_per_hr"] = b
 
         if object_name_path[-1] == "LoadProfile":
             if self.isValid:

--- a/reo/validators.py
+++ b/reo/validators.py
@@ -1295,15 +1295,6 @@ class ValidateNestedInput:
                 if self.input_dict['Scenario']['Site']['Generator'].get('emissions_factor_lb_PM25_per_gal') is None:
                     self.update_attribute_value(object_name_path, number, 'emissions_factor_lb_PM25_per_gal', self.fuel_conversion_lb_PM25_per_gal.get('diesel_oil'))
                 
-                # if (real_values["max_kw"] > 0 or real_values["existing_kw"] > 0):
-                #     # then replace zeros in default burn rate and slope, and set min/max kw values appropriately for
-                #     # REopt (which need to be in place before data is saved and passed on to celery tasks)
-                #     gen = real_values
-                #     m, b = Generator.default_fuel_burn_rate(gen["min_kw"] + gen["existing_kw"])
-                #     if gen["fuel_slope_gal_per_kwh"] == 0:
-                #         gen["fuel_slope_gal_per_kwh"] = m
-                #     if gen["fuel_intercept_gal_per_hr"] == 0:
-                #         gen["fuel_intercept_gal_per_hr"] = b
 
         if object_name_path[-1] == "LoadProfile":
             if self.isValid:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [all existing tests passed ] Tests for the changes have been added (for bug fixes / features) 
- [n/a - inputs now align with docs ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Update to diesel fuel burn rate inputs.

### What is the current behavior?
(You can also link to an open issue here)
Previously:  Overrode user inputs of 0 for `fuel_slope_gal_per_kwh` and `fuel_intercept_gal_per_hr` with default values. This prevented users from ever entering 0 for these values (which is only an issue for fuel_intercept). Users were not notified of this override.


### What is the new behavior (if this is a feature change)?
User inputs for `fuel_slope_gal_per_kwh` and `fuel_intercept_gal_per_hr` will be used. Default values are 0.076 and 0, respectively.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)

Yes. Analyses with user inputs of 0 for `fuel_slope_gal_per_kwh` and `fuel_intercept_gal_per_hr` will have previously used REopt defaults (from techs.py `default_fuel_burn_rate`), but will now use user inputs. Users can change their inputs to the defaults in `default_fuel_burn_rate` to obtain the same results as previously reported.
