### PR TITLE
avoid triggering duplicate github workflows

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -3,6 +3,10 @@ name: Built-in Tests for Pull Requests (Xpress in Ubuntu 18.04)
 on:
 
   pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
     branches:
       - master
       - develop

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -3,6 +3,9 @@ name: Built-in Tests for Push (Xpress in Ubuntu 18.04)
 on:
 
   push:
+    paths-ignore:
+      - README.md
+      - CHANGELOG.md
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Classify the change according to the following categories:
 ## Develop - 2022-07-19
 ### Minor Updates 
 ##### Changed
+- Don't trigger Built-in Tests workflow on a push that only changes README.md and/or CHANGELOG.md
 - Avoid triggering duplicate GitHub workflows. When pushing to a branch that's in a PR, only trigger tests on the push not on the PR sync also.
 
 ## Develop - 2022-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop - 2022-07-19
+### Minor Updates 
+##### Changed
+- Avoid triggering duplicate GitHub workflows. When pushing to a branch that's in a PR, only trigger tests on the push not on the PR sync also.
+
 ## Develop - 2022-06-27
 ### Minor Updates 
 ##### Changed


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
updates GitHub workflows for pushes and PRs



### What is the current behavior?
triggering built in test workflows unnecessarily or duplicates


### What is the new behavior (if this is a feature change)?
a push to a branch with a PR triggers push tests to run but not PR tests to run
pushes that only change markdown files don't trigger tests to run


### Does this PR introduce a breaking change?
no


### Other information:
