### PR TITLE
add v2/outagesimjob and v2/ghpghx urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Classify the change according to the following categories:
 - Require ElectricTariff key in inputs when **Settings.off_grid_flag** is false
 - Create and save **ElectricUtilityInputs** model if ElectricUtility key not provided in inputs when **Settings.off_grid_flag** is false, in order to use the default inputs in `job/models.py`
 - Added message to `messages()` to alert user if valid ElectricUtility input is provided when **Settings.off_grid_flag** is true
+- Register `OutageSimJob()` and `GHPGHXJob()` to the 'v2' API in `urls.py`, making the `v2/outagesimjob` and `v2/ghpghx` urls available
 ##### Changed
 - `job/models.py`: remove Generator `fuel_slope_gal_per_kwh` and `fuel_intercept_gal_per_hr` defaults based on size, keep defaults independent of size 
 - `job/validators.py`: Align PV tilt and aziumth defaults with API v2 behavior, based on location and PV type

--- a/reopt_api/urls.py
+++ b/reopt_api/urls.py
@@ -46,6 +46,8 @@ v1_api.register(GHPGHXJob())
 
 v2_api = Api(api_name='v2')
 v2_api.register(Job2())
+v2_api.register(OutageSimJob())
+v2_api.register(GHPGHXJob())
 
 stable_api = Api(api_name='stable')
 stable_api.register(Job2())

--- a/resilience_stats/tests/test_new_post_endpoint.py
+++ b/resilience_stats/tests/test_new_post_endpoint.py
@@ -40,12 +40,12 @@ class OutageSimTests(ResourceTestCaseMixin, TestCase):
         super(OutageSimTests, self).setUp()
 
         # for optimization module
-        self.reopt_base_opt = '/v1/job/'
+        self.reopt_base_opt = '/v2/job/'
         self.post_opt = os.path.join('resilience_stats', 'tests', 'optPOST.json')
         self.run_uuid = None
 
         #for simulation module
-        self.reopt_base_sim = '/v1/outagesimjob/'
+        self.reopt_base_sim = '/v2/outagesimjob/'
 
 
     def get_response_opt(self, data):


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
bug fix

### What is the current behavior?
the v2/outagesimjob and v2/ghpghx urls are not made available to access the OutageSimJob() and GHPGHXJob() tasks

### What is the new behavior (if this is a feature change)?
the v2/outagesimjob and v2/ghpghx urls are added

### Does this PR introduce a breaking change?
no

### Other information:
