### PR TITLE
Update http.jl

### DIFF
--- a/.helm/templates/julia-deployment.yaml
+++ b/.helm/templates/julia-deployment.yaml
@@ -51,6 +51,4 @@ spec:
             requests:
               cpu: {{ .Values.juliaCpuRequest | quote }}
               memory: {{ .Values.juliaMemoryRequest | quote }}
-            limits:
-              cpu: {{ .Values.juliaCpuLimit | quote }}
-              memory: {{ .Values.juliaMemoryLimit | quote }}
+

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -20,8 +20,9 @@ function job(req::HTTP.Request)
 	end
     optimizer = backend(m)
 	finalize(optimizer)
-	GC.gc()
     Xpress.postsolve(optimizer.inner)
+	empty!(m)
+	GC.gc()
 	if isempty(error_response)
     	@info "REopt model solved with status $(results["status"])."
     	return HTTP.Response(200, JSON.json(results))
@@ -115,8 +116,11 @@ function reopt(req::HTTP.Request)
 	if typeof(ms) <: AbstractArray
 		finalize(backend(ms[1]))
 		finalize(backend(ms[2]))
+		empty!(ms[1])
+		empty!(ms[2])
 	else
 		finalize(backend(ms))
+		empty!(ms)
 	end
     GC.gc()
 


### PR DESCRIPTION
`empty!()` the JuMP models post solve before `GC.gc()`

### Please check if the PR fulfills these requirements
- [ ] CHANGELOG.md is updated
- [X] Tests for the changes have been added (for bug fixes / features) (see other information)
- [X] Docs have been added / updated (for bug fixes / features) (see other information)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Memory management feature for JuMP models


### What is the current behavior?
(You can also link to an open issue here)
Post solve, JuMP models are finalized and handled before garbage collection. However, upon initial testing this does not reduce the size of JuMP models (might even increase the size in some cases).


### What is the new behavior (if this is a feature change)?
Now, the JuMP models will be `empty!()` before the `GC.gc()` is called which should free up memory held by these models post solve


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No


### Other information:
If all inbuilt API tests pass, testing for this PR will have to be via Rancher. We would have to monitor resource consumption there and see if there is a reduction in how often the infrastructure is out of memory. See Issue #417 for more details on tests done using VM.
No user facing docs need to be updated.