### PR TITLE
change ubuntu-18.04 to ubuntu-latest in github actions

### DIFF
--- a/.github/disabled_cbc_workflows/push_test_cbc.yml
+++ b/.github/disabled_cbc_workflows/push_test_cbc.yml
@@ -1,4 +1,4 @@
-name: Built-in Tests for Push (Cbc in Ubuntu 18.04)
+name: Built-in Tests for Push (Cbc in latest Ubuntu)
 
 on:
 
@@ -9,7 +9,7 @@ on:
 jobs:
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -1,4 +1,4 @@
-name: Built-in Tests for Pull Requests (Xpress in Ubuntu 18.04)
+name: Built-in Tests for Pull Requests (Xpress in latest Ubuntu)
 
 on:
 
@@ -14,7 +14,7 @@ on:
 jobs:
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2      

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -1,4 +1,4 @@
-name: Built-in Tests for Push (Xpress in Ubuntu 18.04)
+name: Built-in Tests for Push (Xpress in latest Ubuntu)
 
 on:
 
@@ -10,7 +10,7 @@ on:
 jobs:
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop
+### Minor Updates
+ ##### Changed
+ - Updated ubuntu-18.04 to ubuntu-latest in GitHub push/pull tests because 18.04 was deprecated in GitHub Actions
+
 ## v2.8.0
 ### Minor Updates
  ##### Changed


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ ] N/A Tests for the changes have been added (for bug fixes / features) 
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
Updated ubuntu-18.04 to ubuntu-latest in GitHub push/pull tests because 18.04 was deprecated in GitHub Actions

### What is the current behavior?
all GitHub actions are automatically cancelled during "awareness brownouts" and will soon always fail

### What is the new behavior (if this is a feature change)?
github actions run again

### Does this PR introduce a breaking change?
no

### Other information:
