### PR TITLE
Add /dev/schedule_stats endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,35 +26,26 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
-## Develop - 2023-03-06
+## Develop - 2023-03-10
 ### Minor Updates
-### Added
+#### Added
 - In **REoptjlMessageOutputs** added a `has_stacktrace` field to denote if response has a stacktrace error or not. Default is False.
-
-## Develop 03/08/2023
-### Minor Updates
-##### Changed
-- Updated the following default values to job/ app (v3):
-   - PV, Wind, Storage, CHP, Hot Water Storage, Cold Water Storage, Electric Storage: **federal_itc_fraction(PV,Wind,CHP)** and **total_itc_fraction(Hot Water Storage, Cold Water Storage, Electric Storage)** to 0.3 (30%)
-   - PV, Wind, Storage, CHP, Hot Water Storage, Cold Water Storage, Electric Storage: ***macrs_bonus_fraction** to 0.8 (80%)
-   - Hot Water Storage and Cold Water Storage: **macrs_option_years** to 7 years
-   
-## Develop - 2023-03-02
- ##### Changed
- - In `reo/nested_inputs.py` v2 inputs (`defaults_dict[2]`), updated the following default values:
-   - ColdTES, HotTES: **macrs_option_years** to 7 (years)
-   - ColdTES, HotTES: ***macrs_bonus_pct** to 0.8 (80%)
-## Develop 11/21/2022
-### Minor Updates
-##### Added
 - Added access to the multiple outage stochastic/robust modeling capabilities in REopt.jl. Not all inputs and outputs are exposed, but the following are:
     - **SiteInputs**: **min_resil_time_steps**
     - **ElectricUtilityInputs**: **outage_start_time_steps**, **outage_durations**, **outage_probabilities**
     - **OutageOutputs**: **expected_outage_cost**, **max_outage_cost_per_outage_duration**, **unserved_load_series**, **unserved_load_per_outage**, **microgrid_upgrade_capital_cost**, **generator_fuel_used_per_outage**
-- added test using multiple outage modeling
-##### Changed
-- use TransactionTestCase instead of TestCase (this avoids whole test being wrapped in a transaction which leads to a TransactionManagementError when doing a database query in the middle)
-- Updated ubuntu-18.04 to ubuntu-latest in GitHub push/pull tests because 18.04 was deprecated in GitHub Actions
+- Added test using multiple outage modeling
+- Add /dev/schedule_stats endpoint
+#### Changed
+ - In `reo/nested_inputs.py` v2 inputs (`defaults_dict[2]`), updated the following default values:
+   - ColdTES, HotTES: **macrs_option_years** to 7 (years)
+   - ColdTES, HotTES: ***macrs_bonus_pct** to 0.8 (80%)
+- Updated the following default values to job/ app (v3):
+   - PV, Wind, Storage, CHP, Hot Water Storage, Cold Water Storage, Electric Storage: **federal_itc_fraction(PV,Wind,CHP)** and **total_itc_fraction(Hot Water Storage, Cold Water Storage, Electric Storage)** to 0.3 (30%)
+   - PV, Wind, Storage, CHP, Hot Water Storage, Cold Water Storage, Electric Storage: ***macrs_bonus_fraction** to 0.8 (80%)
+   - Hot Water Storage and Cold Water Storage: **macrs_option_years** to 7 years
+- Use TransactionTestCase instead of TestCase (this avoids whole test being wrapped in a transaction which leads to a TransactionManagementError when doing a database query in the middle)
+- Updated ubuntu-18.04 to ubuntu-latest in GitHub push/pull tests because 18.04 was deprecated in GitHub Actions   
 
 ## v2.8.0
 ### Minor Updates

--- a/job/urls.py
+++ b/job/urls.py
@@ -42,4 +42,5 @@ urlpatterns = [
 
     re_path(r'^invalid_urdb/?$', reoviews.invalid_urdb),
     re_path(r'^emissions_profile/?$', reoviews.emissions_profile),
+    re_path(r'^schedule_stats/?$', reoviews.schedule_stats),
 ]


### PR DESCRIPTION
Reuse the same `reo` view `schedule_stats` function for `/dev/schedule_stats` because this endpoint is purely a user-interface helper endpoint.
