### PR TITLE
Update ERP PrimeGen Input Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+### Patches
 ## v2.10.0
 ### Minor Updates
 ##### Added

--- a/resilience_stats/models.py
+++ b/resilience_stats/models.py
@@ -294,7 +294,7 @@ class ERPPrimeGeneratorInputs(BaseModel, models.Model):
         help_text=("Electric efficiency of prime generator/CHP unit running at full load.")
     )
 
-    def op_avail(prime_mover, is_chp, size_kw):
+    def op_avail(self, prime_mover, is_chp, size_kw):
         size_class_index = 1 if (
                 prime_mover == "recip_engine" and size_kw > 800
             ) or (
@@ -315,7 +315,7 @@ class ERPPrimeGeneratorInputs(BaseModel, models.Model):
                 }
             }[is_chp][prime_mover][size_class_index]
         
-    def mttf(prime_mover, is_chp, size_kw):
+    def mttf(self, prime_mover, is_chp, size_kw):
         size_class_index = 1 if (
                 prime_mover == "recip_engine" and size_kw > 800
             ) or (
@@ -337,12 +337,15 @@ class ERPPrimeGeneratorInputs(BaseModel, models.Model):
             }[is_chp][prime_mover][size_class_index]
 
     def clean(self):
+        prime_mover = str(self.prime_mover)
+        is_chp = bool(self.is_chp)
+        size_kw = float(self.size_kw)
         if not self.electric_efficiency_half_load:
             self.electric_efficiency_half_load = self.electric_efficiency_full_load
         if not self.operational_availability:
-            self.operational_availability = self.op_avail(self.prime_mover, self.is_chp, self.size_kw)
+            self.operational_availability = self.op_avail(prime_mover, is_chp, size_kw)
         if not self.mean_time_to_failure:
-            self.mean_time_to_failure = self.mttf(self.prime_mover, self.is_chp, self.size_kw)
+            self.mean_time_to_failure = self.mttf(prime_mover, is_chp, size_kw)
         error_messages = {}
         if self.operational_availability is None and self.mean_time_to_failure is None:
             error_messages["required inputs"] = "Must provide operational_availability and mean_time_to_failure to model {} with the specified prime_mover".format(self.key)
@@ -360,8 +363,8 @@ class ERPPrimeGeneratorInputs(BaseModel, models.Model):
 
     def info_dict_with_dependent_defaults(self, prime_mover:str, is_chp:bool, size_kw:float):
         d = self.info_dict(self)
-        d["operational_availability"]["default"] = self.op_avail(prime_mover, is_chp, size_kw)
-        d["mean_time_to_failure"]["default"] = self.mttf(prime_mover, is_chp, size_kw)
+        d["operational_availability"]["default"] = self.op_avail(self, prime_mover, is_chp, size_kw)
+        d["mean_time_to_failure"]["default"] = self.mttf(self, prime_mover, is_chp, size_kw)
         return d
 
 class ERPElectricStorageInputs(BaseModel, models.Model):


### PR DESCRIPTION
Changes to ERP prime generator inputs types

### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix



### What is the current behavior?
ERP posts from UI to /erp endpoint returned the following errors:

- "op_avail() takes 3 positional argument but 4 were given"
- "mttf() takes 3 positional argument but 4 were given"
- datatype mismatch error



### What is the new behavior (if this is a feature change)?



### Does this PR introduce a breaking change?
No.



### Other information:
