### PR TITLE
Increase julia mem and empty! model

### DIFF
--- a/.helm/values.production.yaml
+++ b/.helm/values.production.yaml
@@ -8,4 +8,4 @@ celeryMemoryRequest: "900Mi"
 celeryMemoryLimit: "900Mi"
 juliaReplicas: 20
 juliaMemoryRequest: "8000Mi"
-juliaMemoryLimit: "8000Mi"
+juliaMemoryLimit: "16000Mi"

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -20,8 +20,9 @@ function job(req::HTTP.Request)
 	end
     optimizer = backend(m)
 	finalize(optimizer)
-	GC.gc()
     Xpress.postsolve(optimizer.inner)
+	empty!(m)
+	GC.gc()
 	if isempty(error_response)
     	@info "REopt model solved with status $(results["status"])."
     	return HTTP.Response(200, JSON.json(results))
@@ -116,8 +117,11 @@ function reopt(req::HTTP.Request)
 	if typeof(ms) <: AbstractArray
 		finalize(backend(ms[1]))
 		finalize(backend(ms[2]))
+		empty!(ms[1])
+		empty!(ms[2])
 	else
 		finalize(backend(ms))
+		empty!(ms)
 	end
     GC.gc()
 


### PR DESCRIPTION
- Increase JuliaMemoryLimit to 16GB, with still a base request of 8GB
- Implement Bhavesh's "empty!(model)" strategy for releasing memory
