### PR TITLE
update summary result order and focus

### DIFF
--- a/job/views.py
+++ b/job/views.py
@@ -699,14 +699,15 @@ def queryset_for_summary(api_metas,summary_dict:dict):
     
     utility = ElectricUtilityInputs.objects.filter(meta__run_uuid__in=run_uuids).only(
         'meta__run_uuid',
+        'outage_start_time_step',
         'outage_start_time_steps'
     )
     if len(utility) > 0:
         for m in utility:
-            if m.outage_start_time_steps is None:
-                summary_dict[str(m.meta.run_uuid)]['focus'] = "Financial"
-            else:
+            if m.outage_start_time_step is not None or m.outage_start_time_steps is not None:
                 summary_dict[str(m.meta.run_uuid)]['focus'] = "Resilience"
+            else:
+                summary_dict[str(m.meta.run_uuid)]['focus'] = "Financial"
     
     tariffInputs = ElectricTariffInputs.objects.filter(meta__run_uuid__in=run_uuids).only(
         'meta__run_uuid',

--- a/job/views.py
+++ b/job/views.py
@@ -544,7 +544,7 @@ def summary(request, user_uuid):
             'run_uuid',
             'status',
             'created'
-        )
+        ).order_by("-created")
 
         unlinked_run_uuids = [i.run_uuid for i in UserUnlinkedRuns.objects.filter(user_uuid=user_uuid)]
         api_metas = [s for s in scenarios if s.run_uuid not in unlinked_run_uuids]
@@ -608,7 +608,7 @@ def summary_by_chunk(request, user_uuid, chunk):
             'run_uuid',
             'status',
             'created'
-        )
+        ).order_by("-created")
 
         unlinked_run_uuids = [i.run_uuid for i in UserUnlinkedRuns.objects.filter(user_uuid=user_uuid)]
         api_metas = [s for s in scenarios if s.run_uuid not in unlinked_run_uuids]
@@ -704,10 +704,10 @@ def queryset_for_summary(api_metas,summary_dict:dict):
     )
     if len(utility) > 0:
         for m in utility:
-            if m.outage_start_time_step is not None or m.outage_start_time_steps is not None:
-                summary_dict[str(m.meta.run_uuid)]['focus'] = "Resilience"
-            else:
+            if m.outage_start_time_step is None or m.outage_start_time_steps is None:
                 summary_dict[str(m.meta.run_uuid)]['focus'] = "Financial"
+            else:
+                summary_dict[str(m.meta.run_uuid)]['focus'] = "Resilience"
     
     tariffInputs = ElectricTariffInputs.objects.filter(meta__run_uuid__in=run_uuids).only(
         'meta__run_uuid',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] CHANGELOG.md is updated N/A
- [X] Tests for the changes have been added (for bug fixes / features) N/A
- [X] Docs have been added / updated (for bug fixes / features) N/A


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Bug fix


### What is the current behavior?
(You can also link to an open issue here)
Currently, the summary endpoint results are in most-recent-last order, but they should be most-recent-first order. The focus is also not set to **Resilience** or **Financial** correctly


### What is the new behavior (if this is a feature change)?
The summary endpoint results are now in most-recent-first descending order. The focus is also set to **Resilience** or **Financial** correctly


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No


### Other information:
