### PR TITLE
Update focus logic and add chp_kw sizes

### DIFF
--- a/job/views.py
+++ b/job/views.py
@@ -704,7 +704,7 @@ def queryset_for_summary(api_metas,summary_dict:dict):
     )
     if len(utility) > 0:
         for m in utility:
-            if m.outage_start_time_step is None or m.outage_start_time_steps is None:
+            if len(m.outage_start_time_steps) == 0:
                 summary_dict[str(m.meta.run_uuid)]['focus'] = "Financial"
             else:
                 summary_dict[str(m.meta.run_uuid)]['focus'] = "Resilience"

--- a/job/views.py
+++ b/job/views.py
@@ -791,6 +791,14 @@ def queryset_for_summary(api_metas,summary_dict:dict):
     if len(gen) > 0:
         for m in gen:
             summary_dict[str(m.meta.run_uuid)]['gen_kw'] = m.size_kw
+
+    chpOutputs = CHPOutputs.objects.filter(meta__run_uuid__in=run_uuids).only(
+            'meta__run_uuid',
+            'size_kw'
+    )
+    if len(chpOutputs) > 0:
+        for m in chpOutputs:
+            summary_dict[str(m.meta.run_uuid)]['chp_kw'] = m.size_kw
     
     return summary_dict
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] CHANGELOG.md is updated N/A
- [X] Tests for the changes have been added (for bug fixes / features) N/A
- [X] Docs have been added / updated (for bug fixes / features) N/A


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Bugs


### What is the current behavior?
(You can also link to an open issue here)
Currently, the focus gets set incorrectly based on comparison to None,and CHP/prime generator size is not returned.


### What is the new behavior (if this is a feature change)?
Focus now gets set on length of outage time steps field and chp/prime generator size gets returned in summary if it was run.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No


### Other information:
