### PR TITLE
Add prime_gen_kw output and logic

### DIFF
--- a/job/views.py
+++ b/job/views.py
@@ -792,13 +792,26 @@ def queryset_for_summary(api_metas,summary_dict:dict):
         for m in gen:
             summary_dict[str(m.meta.run_uuid)]['gen_kw'] = m.size_kw
 
+    # assumes run_uuids exist in both CHPInputs and CHPOutputs
+    chpInputs = CHPInputs.objects.filter(meta__run_uuid__in=run_uuids).only(
+            'meta__run_uuid',
+            'thermal_efficiency_full_load'
+    )
+    thermal_efficiency_full_load = dict()
+    if len(chpInputs) > 0:
+        for m in chpInputs:
+            thermal_efficiency_full_load[str(m.meta.run_uuid)] = m.thermal_efficiency_full_load
+    
     chpOutputs = CHPOutputs.objects.filter(meta__run_uuid__in=run_uuids).only(
             'meta__run_uuid',
             'size_kw'
     )
     if len(chpOutputs) > 0:
         for m in chpOutputs:
-            summary_dict[str(m.meta.run_uuid)]['chp_kw'] = m.size_kw
+            if thermal_efficiency_full_load[str(m.meta.run_uuid)] == 0:
+                summary_dict[str(m.meta.run_uuid)]['prime_gen_kw'] = m.size_kw
+            else:
+                summary_dict[str(m.meta.run_uuid)]['chp_kw'] = m.size_kw
     
     return summary_dict
 


### PR DESCRIPTION
add prime_gen_kw and logic for setting that value.

### Please check if the PR fulfills these requirements
- [X] CHANGELOG.md is updated N/A
- [X] Tests for the changes have been added (for bug fixes / features) N/A
- [X] Docs have been added / updated (for bug fixes / features) N/A


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Bug fix


### What is the current behavior?
(You can also link to an open issue here)
Currently, prime_gen_kw value is returned under the chp_kw key with no way to distinguish the tech being modeled via this value


### What is the new behavior (if this is a feature change)?
Now, prime_gen_kw represents prime generator kW whereas chp_kw represents chp kW


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No


### Other information:
