### PR TITLE
convert cooling_pct_share to floating point numbers in http.jl simulated_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Classify the change according to the following categories:
 - Add `/ghp_efficiency_thermal_factors` endpoint to `job` app for v
 ##### Changed
 - Update a couple of GHP functions to use the GhpGhx.jl package instead of previous Julia scripts and data from v2
+##### Fixed
+- Fixed a type mismatch bug in the `simulated_load` function within http.jl
 
 ## v2.14.0
 ### Minor Updates

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -334,6 +334,10 @@ function simulated_load(req::HTTP.Request)
         d["percent_share"] = convert(Vector{Float64}, d["percent_share"])
     end
 
+    if "cooling_pct_share" in keys(d) && typeof(d["cooling_pct_share"]) <: Vector{}
+        d["cooling_pct_share"] = convert(Vector{Float64}, d["cooling_pct_share"])
+    end
+
     @info "Getting CRB Loads..."
     data = Dict()
     error_response = Dict()


### PR DESCRIPTION

### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
bug fix


### What is the current behavior?
(You can also link to an open issue here)
`simulated_load` throws an error in cooling load for blended reference buildings, type mismatch with REopt.jl requirements


### What is the new behavior (if this is a feature change)?
`cooling_pct_share` now is converted to a vector of floats in the `simulated_load` function within http.jl


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)



### Other information:
