### PR TITLE
Update ExistingChiller cop inputs from Julia

### DIFF
--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -112,11 +112,20 @@ function reopt(req::HTTP.Request)
             else
                 ghp_dict = Dict()
             end
+            if haskey(d, "CoolingLoad")
+                inputs_with_defaults_from_chiller = [
+                    :cop
+                ]
+                chiller_dict = Dict(key=>getfield(model_inputs.s.existing_chiller, key) for key in inputs_with_defaults_from_chiller)
+            else
+                chiller_dict = Dict()
+            end          
 			inputs_with_defaults_set_in_julia = Dict(
 				"Financial" => Dict(key=>getfield(model_inputs.s.financial, key) for key in inputs_with_defaults_from_easiur),
 				"ElectricUtility" => Dict(key=>getfield(model_inputs.s.electric_utility, key) for key in inputs_with_defaults_from_avert),
                 "CHP" => chp_dict,
-                "GHP" => ghp_dict
+                "GHP" => ghp_dict,
+                "ExistingChiller" => chiller_dict
 			)            
 		catch e
 			@error "Something went wrong in REopt optimization!" exception=(e, catch_backtrace())

--- a/reoptjl/src/process_results.py
+++ b/reoptjl/src/process_results.py
@@ -33,7 +33,8 @@ from reoptjl.models import FinancialOutputs, APIMeta, PVOutputs, ElectricStorage
                         ElectricUtilityInputs, ExistingBoilerOutputs, CHPOutputs, CHPInputs, \
                         ExistingChillerOutputs, CoolingLoadOutputs, HeatingLoadOutputs,\
                         HotThermalStorageOutputs, ColdThermalStorageOutputs, OutageOutputs,\
-                        REoptjlMessageOutputs, AbsorptionChillerOutputs, GHPInputs, GHPOutputs
+                        REoptjlMessageOutputs, AbsorptionChillerOutputs, GHPInputs, GHPOutputs,\
+                        ExistingChillerInputs
 import numpy as np
 import sys
 import traceback as tb
@@ -139,6 +140,12 @@ def update_inputs_in_database(inputs_to_update: dict, run_uuid: str) -> None:
             CHPInputs.objects.filter(meta__run_uuid=run_uuid).update(**inputs_to_update["CHP"])
         if inputs_to_update["GHP"]:
             GHPInputs.objects.filter(meta__run_uuid=run_uuid).update(**inputs_to_update["GHP"])
+        if inputs_to_update["ExistingChiller"]:
+            if not ExistingChillerInputs.objects.filter(meta__run_uuid=run_uuid):
+                meta = APIMeta.objects.get(run_uuid=run_uuid)
+                ExistingChillerInputs.create(meta=meta, **inputs_to_update["ExistingChiller"]).save()
+            else:
+                ExistingChillerInputs.objects.filter(meta__run_uuid=run_uuid).update(**inputs_to_update["ExistingChiller"])
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         debug_msg = "exc_type: {}; exc_value: {}; exc_traceback: {}".format(


### PR DESCRIPTION
Hot fix for adding `ExistingChiller.cop` to API response inputs when relying on REopt.jl logic for the default value (dependent on cooling load).
