### PR TITLE
Add endpoint get_existing_chiller_default_cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ Classify the change according to the following categories:
 ### Minor Updates
 ##### Added
 - Add `GHP` to `job` app for v3
-- Add `/ghp_efficiency_thermal_factors` endpoint to `job` app for v
+- Add `/ghp_efficiency_thermal_factors` endpoint to `job` app for v3
+- Add `/get_existing_chiller_default_cop` endpoint to `job` app for v3
 ##### Changed
 - Update a couple of GHP functions to use the GhpGhx.jl package instead of previous Julia scripts and data from v2
 ##### Fixed

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -432,12 +432,21 @@ end
 
 function get_existing_chiller_default_cop(req::HTTP.Request)
     d = JSON.parse(String(req.body))
+    chiller_cop = nothing
+
+    for key in ["existing_chiller_max_thermal_factor_on_peak_load","max_load_kw","max_load_kw_thermal"]
+        if !(key in keys(d))
+            d[key] = nothing
+        end
+    end
     
     @info "Getting default existing chiller COP..."
+    error_response = Dict()
     try
-        chiller_cop = reoptjl.(d["existing_chiller_max_thermal_factor_on_peak_load"], 
-                    d["max_load_kw"],
-                    d["max_load_kw_thermal"])      
+        chiller_cop = reoptjl.get_existing_chiller_default_cop(;
+                existing_chiller_max_thermal_factor_on_peak_load=d["existing_chiller_max_thermal_factor_on_peak_load"], 
+                max_load_kw=d["max_load_kw"],
+                max_load_kw_thermal=d["max_load_kw_thermal"])      
     catch e
         @error "Something went wrong in the get_existing_chiller_default_cop" exception=(e, catch_backtrace())
         error_response["error"] = sprint(showerror, e)
@@ -445,8 +454,9 @@ function get_existing_chiller_default_cop(req::HTTP.Request)
     if isempty(error_response)
         @info("Default existing chiller COP detected.")
         response = Dict([("existing_chiller_cop", chiller_cop)])
+        return HTTP.Response(200, JSON.json(response))
     else
-        @info "An error occured in the ground_conductivity endpoint"
+        @info "An error occured in the get_existing_chiller_default_cop endpoint"
         return HTTP.Response(500, JSON.json(error_response))
     end
 end    

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -430,7 +430,7 @@ function health(req::HTTP.Request)
     return HTTP.Response(200, JSON.json(Dict("Julia-api"=>"healthy!")))
 end
 
-function get_existing_chiller_default_cop(req:HTTP.Request)
+function get_existing_chiller_default_cop(req::HTTP.Request)
     d = JSON.parse(String(req.body))
     
     @info "Getting default existing chiller COP..."
@@ -444,7 +444,7 @@ function get_existing_chiller_default_cop(req:HTTP.Request)
     end
     if isempty(error_response)
         @info("Default existing chiller COP detected.")
-        response = Dict([("chiller_cop", chiller_cop)])
+        response = Dict([("existing_chiller_cop", chiller_cop)])
     else
         @info "An error occured in the ground_conductivity endpoint"
         return HTTP.Response(500, JSON.json(error_response))

--- a/reoptjl/test/test_http_endpoints.py
+++ b/reoptjl/test/test_http_endpoints.py
@@ -182,3 +182,17 @@ class TestHTTPEndpoints(ResourceTestCaseMixin, TestCase):
         view_response = json.loads(resp.content)
 
         self.assertEqual(view_response["thermal_conductivity"], 1.117)
+
+    def test_default_existing_chiller_cop(self):
+        inputs_dict = {
+            "existing_chiller_max_thermal_factor_on_peak_load":1.25,
+            "max_load_kw": 50,
+            "max_load_kw_thermal":100
+        }
+
+        # Call to the django view endpoint /ghp_efficiency_thermal_factors which calls the http.jl endpoint
+        resp = self.api_client.get(f'/dev/get_existing_chiller_default_cop', data=inputs_dict)
+        view_response = json.loads(resp.content)
+        print(view_response)
+
+        self.assertEqual(view_response["existing_chiller_cop"], 4.4)

--- a/reoptjl/test/test_job_endpoint.py
+++ b/reoptjl/test/test_job_endpoint.py
@@ -64,7 +64,7 @@ class TestJobEndpoint(ResourceTestCaseMixin, TransactionTestCase):
 
     def test_pv_battery_and_emissions_defaults_from_julia(self):
         """
-        Same test post as"Solar and Storage w/BAU" in the Julia package. Used in development of v3.
+        Same test post as"Solar and ElectricStorage w/BAU" in the Julia package. Used in development of v3.
         Also tests that inputs with defaults determined in the REopt julia package get updated in the database.
         """
         post_file = os.path.join('reoptjl', 'test', 'posts', 'pv_batt_emissions.json')
@@ -79,11 +79,11 @@ class TestJobEndpoint(ResourceTestCaseMixin, TransactionTestCase):
         r = json.loads(resp.content)
         results = r["outputs"]
 
-        self.assertAlmostEqual(results["Financial"]["lcc"], 1.240037e7, places=-3)
+        self.assertAlmostEqual(results["Financial"]["lcc"], 12391786, places=-3)
         self.assertAlmostEqual(results["Financial"]["lcc_bau"], 12766397, places=-3)
         self.assertAlmostEqual(results["PV"]["size_kw"], 216.667, places=1)
-        self.assertAlmostEqual(results["ElectricStorage"]["size_kw"], 55.9, places=1)
-        self.assertAlmostEqual(results["ElectricStorage"]["size_kwh"], 78.9, places=1)
+        self.assertAlmostEqual(results["ElectricStorage"]["size_kw"], 49.05, places=1)
+        self.assertAlmostEqual(results["ElectricStorage"]["size_kwh"], 83.32, places=1)
     
         self.assertIsNotNone(results["Site"]["total_renewable_energy_fraction"])
         self.assertIsNotNone(results["Site"]["annual_emissions_tonnes_CO2"])

--- a/reoptjl/urls.py
+++ b/reoptjl/urls.py
@@ -48,4 +48,5 @@ urlpatterns = [
     re_path(r'^peak_load_outage_times/?$', views.peak_load_outage_times),
     re_path(r'^invalid_urdb/?$', reoviews.invalid_urdb),
     re_path(r'^schedule_stats/?$', reoviews.schedule_stats),
+    re_path(r'^get_existing_chiller_default_cop/?$', views.get_existing_chiller_default_cop),
 ]

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -577,6 +577,43 @@ def ghp_efficiency_thermal_factors(request):
         log.debug(debug_msg)
         return JsonResponse({"Error": "Unexpected error in ghp_efficiency_thermal_factors endpoint. Check log for more."}, status=500)
 
+def get_existing_chiller_default_cop(request):
+    """
+    GET default existing chiller COP using the max thermal cooling load.
+    param: existing_chiller_max_thermal_factor_on_peak_load: max thermal factor on peak cooling load, i.e., "oversizing" of existing chiller [fraction]
+    param: max_load_kw: maximum electrical load [kW]
+    param: max_load_kw_thermal: maximum thermal cooling load [kW]
+    return: existing_chiller_cop: default COP of existing chiller [fraction]  
+    """
+    try:
+        existing_chiller_max_thermal_factor_on_peak_load = float(request.GET['existing_chiller_max_thermal_factor_on_peak_load'])  # need float to convert unicode
+        max_load_kw = float(request.GET['max_load_kw'])
+        max_load_kw_thermal = float(request.GET['max_load_kw_thermal'])
+
+        inputs_dict = {"existing_chiller_max_thermal_factor_on_peak_load": existing_chiller_max_thermal_factor_on_peak_load,
+                        "max_load_kw": max_load_kw,
+                        "max_load_kw_thermal": max_load_kw_thermal}
+
+        julia_host = os.environ.get('JULIA_HOST', "julia")
+        http_jl_response = requests.get("http://" + julia_host + ":8081/get_existing_chiller_default_cop/", json=inputs_dict)
+        response = JsonResponse(
+            http_jl_response.json()
+        )
+        return response
+
+    except ValueError as e:
+        return JsonResponse({"Error": str(e.args[0])}, status=500)
+
+    except KeyError as e:
+        return JsonResponse({"Error. Missing": str(e.args[0])}, status=500)
+
+    except Exception:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        debug_msg = "exc_type: {}; exc_value: {}; exc_traceback: {}".format(exc_type, exc_value.args[0],
+                                                                            tb.format_tb(exc_traceback))
+        log.debug(debug_msg)
+        return JsonResponse({"Error": "Unexpected error in get_existing_chiller_default_cop endpoint. Check log for more."}, status=500)
+
     
 def summary(request, user_uuid):
     """


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Feature


### What is the current behavior?
(You can also link to an open issue here)
No endpoint to call Julia to obtain existing chiller COP when pre-populating database (this can be done after the solve)


### What is the new behavior (if this is a feature change)?
new HTTP endpoint `get_existing_chiller_default_cop` performs this task, which allows for access to UI when generating uploaded cooling loads 


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No


### Other information:
