### PR TITLE
Update chiller cop call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop 2023/09/06
+### Minor Updates
+##### Fixed
+- Fixed a bug in the `get_existing_chiller_default_cop` endpoint not accepting blank/null inputs that are optional
+
 ## v2.15.0
 ### Minor Updates
 ##### Added

--- a/reoptjl/test/test_http_endpoints.py
+++ b/reoptjl/test/test_http_endpoints.py
@@ -218,9 +218,21 @@ class TestHTTPEndpoints(ResourceTestCaseMixin, TestCase):
             "max_load_kw_thermal":100
         }
 
-        # Call to the django view endpoint /ghp_efficiency_thermal_factors which calls the http.jl endpoint
+        # Call to the django view endpoint /get_existing_chiller_default_cop which calls the http.jl endpoint
         resp = self.api_client.get(f'/dev/get_existing_chiller_default_cop', data=inputs_dict)
         view_response = json.loads(resp.content)
         print(view_response)
 
         self.assertEqual(view_response["existing_chiller_cop"], 4.4)
+
+        # Test empty dictionary, which should return unknown value
+        inputs_dict = {}
+
+        # Call to the django view endpoint /get_existing_chiller_default_cop which calls the http.jl endpoint
+        resp = self.api_client.get(f'/dev/get_existing_chiller_default_cop', data=inputs_dict)
+        view_response = json.loads(resp.content)
+        print(view_response)
+
+        self.assertEqual(view_response["existing_chiller_cop"], 4.545)
+
+        

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -596,6 +596,7 @@ def get_existing_chiller_default_cop(request):
         inputs_dict = {}
         for key in ['existing_chiller_max_thermal_factor_on_peak_load','max_load_kw','max_load_kw_thermal']:
             inputs_dict[key] = request.GET.get(key)
+            # allow empty keys to be None, convert all other inputs to floats
             if inputs_dict[key] is not None:
                 inputs_dict[key] = float(inputs_dict[key])
 

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -593,14 +593,27 @@ def get_existing_chiller_default_cop(request):
     return: existing_chiller_cop: default COP of existing chiller [fraction]  
     """
     try:
-        inputs_dict = {}
-        for key in ['existing_chiller_max_thermal_factor_on_peak_load','max_load_kw','max_load_kw_thermal']:
-            inputs_dict[key] = request.GET.get(key)
-            # allow empty keys to be None, convert all other inputs to floats
-            if inputs_dict[key] is not None:
-                inputs_dict[key] = float(inputs_dict[key])
-            elif key == 'existing_chiller_max_thermal_factor_on_peak_load':
-                inputs_dict[key] = 1.25  #default value
+        existing_chiller_max_thermal_factor_on_peak_load = request.GET.get('existing_chiller_max_thermal_factor_on_peak_load')
+        if existing_chiller_max_thermal_factor_on_peak_load is not None:
+            existing_chiller_max_thermal_factor_on_peak_load = float(existing_chiller_max_thermal_factor_on_peak_load)
+        else: 
+            existing_chiller_max_thermal_factor_on_peak_load = 1.25  # default from REopt.jl
+
+        max_load_kw = request.GET.get('max_load_kw')
+        if max_load_kw is not None:
+            max_load_kw = float(max_load_kw)
+
+        max_load_ton = request.GET.get('max_load_ton')
+        if max_load_ton is not None:
+            max_load_kw_thermal = float(max_load_ton) * 3.51685  # kWh thermal per ton-hour
+        else: 
+            max_load_kw_thermal = None
+            
+        inputs_dict = {
+            "existing_chiller_max_thermal_factor_on_peak_load": existing_chiller_max_thermal_factor_on_peak_load,
+            "max_load_kw": max_load_kw,
+            "max_load_kw_thermal": max_load_kw_thermal
+        }
 
         julia_host = os.environ.get('JULIA_HOST', "julia")
         http_jl_response = requests.get("http://" + julia_host + ":8081/get_existing_chiller_default_cop/", json=inputs_dict)

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -593,13 +593,11 @@ def get_existing_chiller_default_cop(request):
     return: existing_chiller_cop: default COP of existing chiller [fraction]  
     """
     try:
-        existing_chiller_max_thermal_factor_on_peak_load = float(request.GET['existing_chiller_max_thermal_factor_on_peak_load'])  # need float to convert unicode
-        max_load_kw = float(request.GET['max_load_kw'])
-        max_load_kw_thermal = float(request.GET['max_load_kw_thermal'])
-
-        inputs_dict = {"existing_chiller_max_thermal_factor_on_peak_load": existing_chiller_max_thermal_factor_on_peak_load,
-                        "max_load_kw": max_load_kw,
-                        "max_load_kw_thermal": max_load_kw_thermal}
+        inputs_dict = {}
+        for key in ['existing_chiller_max_thermal_factor_on_peak_load','max_load_kw','max_load_kw_thermal']:
+            inputs_dict[key] = request.GET.get(key)
+            if inputs_dict[key] is not None:
+                inputs_dict[key] = float(inputs_dict[key])
 
         julia_host = os.environ.get('JULIA_HOST', "julia")
         http_jl_response = requests.get("http://" + julia_host + ":8081/get_existing_chiller_default_cop/", json=inputs_dict)

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -599,6 +599,8 @@ def get_existing_chiller_default_cop(request):
             # allow empty keys to be None, convert all other inputs to floats
             if inputs_dict[key] is not None:
                 inputs_dict[key] = float(inputs_dict[key])
+            elif key == 'existing_chiller_max_thermal_factor_on_peak_load':
+                inputs_dict[key] = 1.25  #default value
 
         julia_host = os.environ.get('JULIA_HOST', "julia")
         http_jl_response = requests.get("http://" + julia_host + ":8081/get_existing_chiller_default_cop/", json=inputs_dict)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Bug fix



### What is the current behavior?
The `get_existing_chiller_default_cop` endpoint only accepts posts with every key populated



### What is the new behavior (if this is a feature change)?
- The `get_existing_chiller_default_cop` endpoint now had all optional inputs; default values are already in place in REopt.jl in the event that `None`/`nothing` is passed to Julia.  **edit 9/7: a default is now in place for the max thermal factor.**
- A new test shows that when no inputs are provided the "unknown" chiller default cop is returned.
- The thermal max load input is in tons, rather than kW; the unit conversion is then performed in the API before calling the REopt.jl function (which converts back to tons).  

### Does this PR introduce a breaking change?
No breaking changes



### Other information:
This should allow for only `max_load_kw` or `max_load_kw_thermal` but not both to be populated in UI calls (which are necessary for the populating chiller COPs for "Upload" and "Custom" cooling loads.