### PR TITLE
Increase Julia pod CPU, decrease celery and Julia count for V3

### DIFF
--- a/.helm/values.production.yaml
+++ b/.helm/values.production.yaml
@@ -3,11 +3,11 @@ djangoSettingsModule: reopt_api.production_settings
 djangoReplicas: 10
 djangoMemoryRequest: "2800Mi"
 djangoMemoryLimit: "2800Mi"
-celeryReplicas: 20
+celeryReplicas: 10
 celeryMemoryRequest: "900Mi"
 celeryMemoryLimit: "900Mi"
-juliaReplicas: 20
-juliaCpuRequest: "300m"
+juliaReplicas: 15
+juliaCpuRequest: "1000m"
 juliaCpuLimit: "4000m"
-juliaMemoryRequest: "8000Mi"
-juliaMemoryLimit: "8000Mi"
+juliaMemoryRequest: "12000Mi"
+juliaMemoryLimit: "12000Mi"

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -15,7 +15,7 @@ djangoMemoryRequest: "1600Mi"
 djangoMemoryLimit: "1600Mi"
 celeryReplicas: 2
 celeryCpuRequest: "100m"
-celeryCpuLimit: "800m"
+celeryCpuLimit: "2000m"
 celeryMemoryRequest: "700Mi"
 celeryMemoryLimit: "700Mi"
 juliaReplicas: 2


### PR DESCRIPTION
For a REopt run with BAU and Optimal, we only use one celery pod instead of two

Each Julia pod will now do threading to use 2 CPU for parallel BAU and Optimal cases, so we increase the CPU there.

We only need 10 Julia (and 10 celery) pods to maintain current parallel processing of runs.

I kept an extra 5 (for a total of 15) Julia pods for those to process endpoints which are largely served through the HTTP.jl server in the Julia pods.

