### PR TITLE
Update chiller cop call

### DIFF
--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -594,17 +594,17 @@ def get_existing_chiller_default_cop(request):
     """
     try:
         existing_chiller_max_thermal_factor_on_peak_load = request.GET.get('existing_chiller_max_thermal_factor_on_peak_load')
-        if existing_chiller_max_thermal_factor_on_peak_load is not None:
+        if existing_chiller_max_thermal_factor_on_peak_load not in [None, ""]:
             existing_chiller_max_thermal_factor_on_peak_load = float(existing_chiller_max_thermal_factor_on_peak_load)
         else: 
             existing_chiller_max_thermal_factor_on_peak_load = 1.25  # default from REopt.jl
 
         max_load_kw = request.GET.get('max_load_kw')
-        if max_load_kw is not None:
+        if max_load_kw not in [None, ""]:
             max_load_kw = float(max_load_kw)
 
         max_load_ton = request.GET.get('max_load_ton')
-        if max_load_ton is not None:
+        if max_load_ton not in [None, ""]:
             max_load_kw_thermal = float(max_load_ton) * 3.51685  # kWh thermal per ton-hour
         else: 
             max_load_kw_thermal = None

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -589,7 +589,7 @@ def get_existing_chiller_default_cop(request):
     GET default existing chiller COP using the max thermal cooling load.
     param: existing_chiller_max_thermal_factor_on_peak_load: max thermal factor on peak cooling load, i.e., "oversizing" of existing chiller [fraction]
     param: max_load_kw: maximum electrical load [kW]
-    param: max_load_kw_thermal: maximum thermal cooling load [kW]
+    param: max_load_ton: maximum thermal cooling load [ton]
     return: existing_chiller_cop: default COP of existing chiller [fraction]  
     """
     try:

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -602,6 +602,8 @@ def get_existing_chiller_default_cop(request):
         max_load_kw = request.GET.get('max_load_kw')
         if max_load_kw not in [None, ""]:
             max_load_kw = float(max_load_kw)
+        else: 
+            max_load_kw = None
 
         max_load_ton = request.GET.get('max_load_ton')
         if max_load_ton not in [None, ""]:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
Allows for an empty string to be passed as a value at the 



### What is the current behavior?
empty or "nil" values are passed as an empty string which yields a type conversion error at the `get_existing_chiller_default_cop` endpoint



### What is the new behavior (if this is a feature change)?
Checks for `None` have been extended to include checks for empty strings as well


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No breaking changes



### Other information:
