### PR TITLE
Defaults updates fy23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,31 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop
+### Changed
+- ANNUAL UPDATE TO DEFAULT VALUES. Changes outlined below with (old value) --> (new value). See user manual for references. 
+  - Owner Discount rate, nominal (%): : **Financial** **owner_discount_rate_fraction** 0.0564	--> 0.0638
+  - Offtaker Discount rate, nominal (%): **Financial**  **offtaker_discount_rate_fraction** 0.0564 --> 0.0638
+  - Electricity cost escalation rate, nominal (%): **Financial** **elec_cost_escalation_rate_fraction** 0.019	--> 0.017
+  - Existing boiler fuel cost escalation rate, nominal (%): **Financial**  **existing_boiler_fuel_cost_escalation_rate_fraction**	0.034	--> 0.015
+  - Boiler fuel cost escalation rate, nominal (%): **Financial** **boiler_fuel_cost_escalation_rate_fraction**	0.034	--> 0.015
+  - CHP fuel cost escalation rate, nominal (%): **Financial**  **chp_fuel_cost_escalation_rate_fraction**	0.034	--> 0.015
+  - Generator fuel cost escalation rate, nominal (%): **Financial**  **generator_fuel_cost_escalation_rate_fraction**	0.027	--> 0.012
+  - Array tilt – Ground mount, Fixed: **PV** **tilt** latitude	--> 20
+  - O&M cost ($/kW/year): **PV** **om_cost_per_kw**	17	--> 18
+  - System capital cost ($/kW): **PV** **installed_cost_per_kw**	1592	--> 1790
+  - Energy capacity cost ($/kWh): **ElectricStorage** **installed_cost_per_kwh**	388	--> 455
+  - Power capacity cost ($/kW): **ElectricStorage**	**installed_cost_per_kw**	775	--> 910
+  - Energy capacity replacement cost ($/kWh): **ElectricStorage** **replace_cost_per_kwh**	220	--> 318
+  - Power capacity replacement cost ($/kW): **ElectricStorage**	**replace_cost_per_kw**	440	--> 715
+  - Fuel burn rate by generator capacity (gal/kWh): **Generator** **fuel_slope_gal_per_kwh**	0.076	--> removed and replaced with full and half-load efficiencies
+  - Electric efficiency at 100% load (% HHV-basis): **Generator** **electric_efficiency_full_load**	N/A - new input	--> 0.322
+  - Electric efficiency at 50% load (% HHV-basis): **Generator** **electric_efficiency_half_load**	N/A - new input	--> 0.322
+  - Generator fuel higher heating value (HHV): **Generator** **fuel_higher_heating_value_kwh_per_gal**	N/A - new input	--> 40.7
+  - System capital cost ($/kW): **Generator**  **installed_cost_per_kw** 500	--> $650 if the generator only runs during outages; $800 if it is allowed to run parallel with the grid; $880 for off-grid
+  - Fixed O&M ($/kW/yr): **Generator** **om_cost_per_kw** Grid connected: 10 Off-grid: 20 --> Grid connected: 20 Off-grid: 10
+  - System capital cost ($/kW) by Class: **Wind** **size_class_to_installed_cost**	residential - 5675 commercial - 4300 medium - 2766 large - 2239 --> residential - 6339 commercial - 4760 medium - 3137 large - 2386
+  - O&M cost ($/kW/year): **Wind** **om_cost_per_kw** 35 --> 36
 ## v3.0.0
 ### Major Updates
 ##### Changed

--- a/reoptjl/models.py
+++ b/reoptjl/models.py
@@ -69,10 +69,10 @@ FUEL_DEFAULTS = {
 }
 
 WIND_COST_DEFAULTS = { # size_class_to_installed_cost 
-    "residential" : 11950.0,
-    "commercial" : 7390.0,
-    "medium" : 4440.0,
-    "large" : 3450.0
+    "residential" : 6339.0,
+    "commercial" : 4760.0,
+    "medium" : 3137.0,
+    "large" : 2386.0
 }
 
 def at_least_one_set(model, possible_sets):

--- a/reoptjl/models.py
+++ b/reoptjl/models.py
@@ -68,6 +68,13 @@ FUEL_DEFAULTS = {
     }
 }
 
+WIND_COST_DEFAULTS = { # size_class_to_installed_cost 
+    "residential" : 11950.0,
+    "commercial" : 7390.0,
+    "medium" : 4440.0,
+    "large" : 3450.0
+}
+
 def at_least_one_set(model, possible_sets):
     """
     Check if at least one set of possible_sets are defined in the Model.dict
@@ -2847,7 +2854,7 @@ class WindInputs(BaseModel, models.Model):
         ],
         blank=True,
         null=True,
-        help_text="Installed cost in $/kW. Default determined based on size_class."
+        help_text="Installed cost in $/kW. Default cost is determined based on size_class."
     )
     om_cost_per_kw = models.FloatField(
         default=36,
@@ -3053,8 +3060,11 @@ class WindInputs(BaseModel, models.Model):
         blank=True,
         help_text="Only applicable when off_grid_flag=True; defaults to 0.5 (50 pct) for off-grid scenarios and fixed at 0 otherwise."
             "Required operating reserves applied to each timestep as a fraction of wind generation serving load in that timestep."
-    ) 
+    )
 
+    def clean(self):
+        if self.size_class != "":
+            self.installed_cost_per_kw = WIND_COST_DEFAULTS.get(self.size_class, None) # will get set in REopt.jl if size_class not supplied
 
 class WindOutputs(BaseModel, models.Model):
     key = "WindOutputs"

--- a/reoptjl/models.py
+++ b/reoptjl/models.py
@@ -582,7 +582,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text="Analysis period in years. Must be integer."
     )
     elec_cost_escalation_rate_fraction = models.FloatField(
-        default=0.019,
+        default=0.017,
         validators=[
             MinValueValidator(-1),
             MaxValueValidator(1)
@@ -591,7 +591,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text="Annual nominal utility electricity cost escalation rate."
     )
     offtaker_discount_rate_fraction = models.FloatField(
-        default=0.0564,
+        default=0.0638,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1)
@@ -619,7 +619,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text="Annual nominal O&M cost escalation rate"
     )
     owner_discount_rate_fraction = models.FloatField(
-        default=0.0564,
+        default=0.0638,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1)
@@ -793,7 +793,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text=("Annual nominal escalation rate of the public health cost of 1 tonne of PM2.5 emissions (as a decimal). The default value is calculated from the EASIUR model for a height of 150m.")
     )
     generator_fuel_cost_escalation_rate_fraction = models.FloatField(
-        default=0.027,
+        default=0.012,
         validators=[
             MinValueValidator(-1),
             MaxValueValidator(1)
@@ -802,7 +802,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text=("Annual nominal boiler fuel cost escalation rate")
     )    
     existing_boiler_fuel_cost_escalation_rate_fraction = models.FloatField(
-        default=0.034,
+        default=0.015,
         validators=[
             MinValueValidator(-1),
             MaxValueValidator(1)
@@ -811,7 +811,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text=("Annual nominal existing boiler fuel cost escalation rate")
     )
     boiler_fuel_cost_escalation_rate_fraction = models.FloatField(
-        default=0.034,
+        default=0.015,
         validators=[
             MinValueValidator(-1),
             MaxValueValidator(1)
@@ -820,7 +820,7 @@ class FinancialInputs(BaseModel, models.Model):
         help_text=("Annual nominal boiler fuel cost escalation rate")
     )
     chp_fuel_cost_escalation_rate_fraction = models.FloatField(
-        default=0.034,
+        default=0.015,
         validators=[
             MinValueValidator(-1),
             MaxValueValidator(1)
@@ -2419,7 +2419,7 @@ class PVInputs(BaseModel, models.Model):
         help_text="Maximum PV size constraint for optimization (upper bound on additional capacity beyond existing_kw). Set to zero to disable PV"
     )
     installed_cost_per_kw = models.FloatField(
-        default=1592,
+        default=1790,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e5)
@@ -2428,7 +2428,7 @@ class PVInputs(BaseModel, models.Model):
         help_text="Installed PV cost in $/kW"
     )
     om_cost_per_kw = models.FloatField(
-        default=17,
+        default=18,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e3)
@@ -2669,7 +2669,7 @@ class PVInputs(BaseModel, models.Model):
         ],
         blank=True,
         null=True,
-        help_text="PV system tilt. If PV system type is rooftop-fixed, then tilt=10 degrees, else tilt=abs(site.latitude)"
+        help_text="PV system tilt. If PV system type is rooftop-fixed, then tilt=10 degrees, else tilt=20 degrees"
     )
     location = models.TextField(
         default=PV_LOCATION_CHOICES.BOTH,
@@ -2841,16 +2841,16 @@ class WindInputs(BaseModel, models.Model):
         help_text="Maximum size constraint for optimization."
     )
     installed_cost_per_kw = models.FloatField(
-        default=1600,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e5)
         ],
         blank=True,
-        help_text="Installed cost in $/kW"
+        null=True,
+        help_text="Installed cost in $/kW. Default determined based on size_class."
     )
     om_cost_per_kw = models.FloatField(
-        default=35,
+        default=36,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e3)
@@ -3044,7 +3044,6 @@ class WindInputs(BaseModel, models.Model):
         blank=True,
         help_text="True/False for if technology has the ability to curtail energy production."
     )
-
     operating_reserve_required_fraction = models.FloatField(
         validators=[
             MinValueValidator(0.0),
@@ -3054,7 +3053,7 @@ class WindInputs(BaseModel, models.Model):
         blank=True,
         help_text="Only applicable when off_grid_flag=True; defaults to 0.5 (50 pct) for off-grid scenarios and fixed at 0 otherwise."
             "Required operating reserves applied to each timestep as a fraction of wind generation serving load in that timestep."
-    )
+    ) 
 
 
 class WindOutputs(BaseModel, models.Model):
@@ -3181,7 +3180,7 @@ class ElectricStorageInputs(BaseModel, models.Model):
         help_text="Flag to set whether the battery can be charged from the grid, or just onsite generation."
     )
     installed_cost_per_kw = models.FloatField(
-        default=775.0,
+        default=910.0,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e4)
@@ -3190,7 +3189,7 @@ class ElectricStorageInputs(BaseModel, models.Model):
         help_text="Total upfront battery power capacity costs (e.g. inverter and balance of power systems)"
     )
     installed_cost_per_kwh = models.FloatField(
-        default=388.0,
+        default=455.0,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e4)
@@ -3199,7 +3198,7 @@ class ElectricStorageInputs(BaseModel, models.Model):
         help_text="Total upfront battery costs"
     )
     replace_cost_per_kw = models.FloatField(
-        default=440.0,
+        default=715.0,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e4)
@@ -3208,7 +3207,7 @@ class ElectricStorageInputs(BaseModel, models.Model):
         help_text="Battery power capacity replacement cost at time of replacement year"
     )
     replace_cost_per_kwh = models.FloatField(
-        default=220.0,
+        default=318.0,
         validators=[
             MinValueValidator(0),
             MaxValueValidator(1.0e4)
@@ -3396,7 +3395,7 @@ class GeneratorInputs(BaseModel, models.Model):
         help_text="Electric efficiency of the generator running at half load. Defaults to electric_efficiency_full_load."
     )
     electric_efficiency_full_load = models.FloatField(
-        default=0.34,
+        default=0.322,
         validators=[
             MinValueValidator(0.0),
             MaxValueValidator(1.0)
@@ -3681,8 +3680,6 @@ class GeneratorInputs(BaseModel, models.Model):
     )
 
     def clean(self):
-        if not self.installed_cost_per_kw:
-            self.installed_cost_per_kw = 650.0 if self.only_runs_during_grid_outage else 800.0
         if not self.electric_efficiency_half_load:
             self.electric_efficiency_half_load = self.electric_efficiency_full_load
 

--- a/reoptjl/test/posts/all_inputs_test.json
+++ b/reoptjl/test/posts/all_inputs_test.json
@@ -2,6 +2,10 @@
     "Financial": {
         "analysis_years": 25,
         "elec_cost_escalation_rate_fraction": 0.023,
+        "existing_boiler_fuel_cost_escalation_rate_fraction": 0.034, 
+        "boiler_fuel_cost_escalation_rate_fraction": 0.034,
+        "chp_fuel_cost_escalation_rate_fraction": 0.034,
+        "generator_fuel_cost_escalation_rate_fraction": 0.027,
         "offtaker_discount_rate_fraction": 0.083,
         "offtaker_tax_rate_fraction": 0.26,
         "om_cost_escalation_rate_fraction": 0.025,

--- a/reoptjl/test/posts/off_grid_validations.json
+++ b/reoptjl/test/posts/off_grid_validations.json
@@ -9,7 +9,6 @@
     "PV": {},
     "Wind": {},
     "Generator": {
-        "installed_cost_per_kw": 700,
         "min_kw": 100,
         "max_kw": 100
     },

--- a/reoptjl/test/posts/off_grid_validations.json
+++ b/reoptjl/test/posts/off_grid_validations.json
@@ -7,7 +7,9 @@
         "latitude": 34.5794343
     },
     "PV": {},
-    "Wind": {},
+    "Wind": {
+        "size_class": "commercial"
+    },
     "Generator": {
         "min_kw": 100,
         "max_kw": 100

--- a/reoptjl/test/posts/outage.json
+++ b/reoptjl/test/posts/outage.json
@@ -41,7 +41,8 @@
         "federal_itc_fraction": 0.26,
         "macrs_bonus_fraction": 1.0,
         "macrs_option_years": 5,
-        "macrs_itc_reduction": 0.5
+        "macrs_itc_reduction": 0.5,
+        "tilt": 39.7407
     },
     "ElectricLoad": {
         "year": 2020,

--- a/reoptjl/test/posts/outage.json
+++ b/reoptjl/test/posts/outage.json
@@ -21,7 +21,9 @@
         "sells_energy_back_to_grid": false,
         "fuel_avail_gal": 660,
         "electric_efficiency_full_load": 0.323289797,
-        "electric_efficiency_half_load": 0.323289797
+        "electric_efficiency_half_load": 0.323289797,
+        "om_cost_per_kw": 10.0,
+        "fuel_cost_per_gallon": 3.0
     },
     "CHP": {
         "thermal_efficiency_full_load": 0.0,
@@ -77,6 +79,10 @@
         "owner_discount_rate_fraction": 0.1,
         "offtaker_discount_rate_fraction": 0.03,
         "elec_cost_escalation_rate_fraction": 0.023,
-        "microgrid_upgrade_cost_fraction": 0.3
+        "microgrid_upgrade_cost_fraction": 0.3,
+        "existing_boiler_fuel_cost_escalation_rate_fraction": 0.034, 
+        "boiler_fuel_cost_escalation_rate_fraction": 0.034,
+        "chp_fuel_cost_escalation_rate_fraction": 0.034,
+        "generator_fuel_cost_escalation_rate_fraction": 0.027
     }
 }

--- a/reoptjl/test/test_job_endpoint.py
+++ b/reoptjl/test/test_job_endpoint.py
@@ -277,6 +277,7 @@ class TestJobEndpoint(ResourceTestCaseMixin, TransactionTestCase):
         """
         Purpose of this test is to test the API's ability to accept all relevant 
         input fields and send to REopt, ensuring name input consistency with REopt.jl.
+        Note: Does not currently test CHP inputs
         """
         post_file = os.path.join('reoptjl', 'test', 'posts', 'all_inputs_test.json')
         post = json.load(open(post_file, 'r'))

--- a/reoptjl/test/test_validator.py
+++ b/reoptjl/test/test_validator.py
@@ -102,6 +102,7 @@ class InputValidatorTests(TestCase):
 
         self.assertAlmostEqual(validator.models["Wind"].operating_reserve_required_fraction, 0.5)
         self.assertAlmostEqual(validator.models["PV"].operating_reserve_required_fraction, 0.25)
+        self.assertEqual(validator.models["Wind"].installed_cost_per_kw, 4760.0) # set based on size_class
 
         self.assertAlmostEqual(validator.models["ElectricLoad"].operating_reserve_required_fraction, 0.1)
         self.assertAlmostEqual(validator.models["ElectricLoad"].critical_load_fraction, 1.0)

--- a/reoptjl/test/test_validator.py
+++ b/reoptjl/test/test_validator.py
@@ -320,7 +320,7 @@ class InputValidatorTests(TestCase):
         validator.clean_fields()
         validator.clean()
         validator.cross_clean()
-        self.assertAlmostEquals(validator.models["PV"].tilt, post["Site"]["latitude"], places=-3)
+        self.assertAlmostEquals(validator.models["PV"].tilt, 20)
 
 
     def boiler_validation(self):

--- a/reoptjl/test/test_validator.py
+++ b/reoptjl/test/test_validator.py
@@ -107,7 +107,8 @@ class InputValidatorTests(TestCase):
         self.assertAlmostEqual(validator.models["ElectricLoad"].critical_load_fraction, 1.0)
         self.assertAlmostEqual(validator.models["ElectricLoad"].min_load_met_annual_fraction, 0.99999)
 
-        self.assertAlmostEqual(validator.models["Generator"].om_cost_per_kw, 20)
+        self.assertAlmostEqual(validator.models["Generator"].installed_cost_per_kw, 880)
+        self.assertAlmostEqual(validator.models["Generator"].om_cost_per_kw, 10)
         self.assertAlmostEqual(validator.models["Generator"].fuel_avail_gal, 1.0e9)
         self.assertAlmostEqual(validator.models["Generator"].min_turn_down_fraction, 0.15)
         self.assertAlmostEqual(validator.models["Generator"].replacement_year, 10)
@@ -116,7 +117,7 @@ class InputValidatorTests(TestCase):
         ## Test that some defaults can be overriden below
 
         post["ElectricLoad"]["operating_reserve_required_fraction"] = 0.2
-        post["ElectricLoad"]["critical_load_fraction"] = 0.95
+        post["ElectricLoad"]["critical_load_fraction"] = 0.95 # cant override
         post["ElectricLoad"]["min_load_met_annual_fraction"] = 0.95
         
         post["Generator"]["om_cost_per_kw"] = 21

--- a/reoptjl/validators.py
+++ b/reoptjl/validators.py
@@ -201,14 +201,14 @@ class InputValidator(object):
         """
 
         """
-        PV tilt set to latitude if not provided and production_factor_series validated
+        PV validation
         """
         def cross_clean_pv(pvmodel):
             if pvmodel.__getattribute__("tilt") == None:
                 if pvmodel.__getattribute__("array_type") == pvmodel.ARRAY_TYPE_CHOICES.ROOFTOP_FIXED:
                     pvmodel.__setattr__("tilt", 10)
                 else:
-                    pvmodel.__setattr__("tilt", abs(self.models["Site"].__getattribute__("latitude")))
+                    pvmodel.__setattr__("tilt", 20)
             
             if pvmodel.__getattribute__("azimuth") == None:
                 if self.models["Site"].__getattribute__("latitude") >= 0:
@@ -276,7 +276,7 @@ class InputValidator(object):
         Wind model validation
         1. If wind resource not provided, add a validation error if lat/lon not within WindToolkit data set
         2. If prod factor or resource data provided, validate_time_series for each
-        NOTE: if size_class is not provided it is determined in the Julia package based off of average load.
+        NOTE: if size_class is not provided: size_class is determined in the Julia package based off of average load and wind installed_cost_per_kw is determined based on size_class.
         """
         if "Wind" in self.models.keys():
             if self.models["Wind"].__getattribute__("max_kw") > 0:
@@ -454,9 +454,15 @@ class InputValidator(object):
 
             if self.models["Generator"].__getattribute__("om_cost_per_kw") == None:
                 if self.models["Settings"].off_grid_flag==False:
-                    self.models["Generator"].om_cost_per_kw = 10.0
-                else:
                     self.models["Generator"].om_cost_per_kw = 20.0
+                    if self.models["Generator"].only_runs_during_grid_outage:
+                        self.models["Generator"].installed_cost_per_kw = 650.0
+                    else: 
+                        self.models["Generator"].installed_cost_per_kw = 800.0
+                    self.models["Generator"]
+                else:
+                    self.models["Generator"].om_cost_per_kw = 10.0
+                    self.models["Generator"].installed_cost_per_kw = 880.0
 
             if self.models["Generator"].__getattribute__("min_turn_down_fraction") == None:
                 if self.models["Settings"].off_grid_flag==False:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) --> User manual will be updated. Markdown text updated in this PR


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Annual update to default values in REopt. Updated to reflect the latest available data (largely, cost data). 

### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
Users will get different results due to updates to defaults. Users can override default values with old values to obtain the same results. See table below. 


### Defaults updates in this PR:

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/afarthin/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/afarthin/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--[if !mso]>
<style>
v\:* {behavior:url(#default#VML);}
o\:* {behavior:url(#default#VML);}
x\:* {behavior:url(#default#VML);}
.shape {behavior:url(#default#VML);}
</style>
<![endif]-->
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding:0px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl66
	{font-weight:700;
	text-align:left;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl67
	{font-weight:700;
	text-align:left;
	border:.5pt solid windowtext;
	background:#FFC000;
	mso-pattern:black none;
	white-space:normal;}
.xl68
	{border:.5pt solid windowtext;}
.xl69
	{text-align:left;
	border:.5pt solid windowtext;}
.xl70
	{text-align:left;
	border:.5pt solid windowtext;
	background:#FFC000;
	mso-pattern:black none;}
.xl71
	{border:.5pt solid windowtext;
	white-space:normal;}
.xl72
	{vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl73
	{text-align:left;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl74
	{text-align:left;
	border:.5pt solid windowtext;
	background:#FFC000;
	mso-pattern:black none;
	white-space:normal;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Input   name (manual) | Reopt Input Key | Reopt input   name | Current Default | New Default
-- | -- | -- | -- | --
Owner Discount   rate, nominal (%) | Financial | owner_discount_rate_fraction | 0.0564 | 0.0638
Offtaker   Discount rate, nominal (%) | Financial | offtaker_discount_rate_fraction | 0.0564 | 0.0638
Electricity cost escalation rate, nominal (%) | Financial | elec_cost_escalation_rate_fraction | 0.019 | 0.017
Existing boiler fuel cost escalation rate, nominal (%) | Financial | existing_boiler_fuel_cost_escalation_rate_fraction | 0.034 | 0.015
Boiler fuel cost escalation rate, nominal (%) | Financial | boiler_fuel_cost_escalation_rate_fraction | 0.034 | 0.015
CHP fuel cost escalation rate, nominal (%) | Financial | chp_fuel_cost_escalation_rate_fraction | 0.034 | 0.015
Generator fuel cost escalation rate, nominal (%) | Financial | generator_fuel_cost_escalation_rate_fraction | 0.027 | 0.012
Array tilt – Ground mount, Fixed | PV | tilt | latitude | 20
O&M cost ($/kW/year) | PV | om_cost_per_kw | 17 | 18
System capital cost ($/kW) | PV | installed_cost_per_kw | 1592 | 1790
Energy capacity cost ($/kWh) | ElectricStorage | installed_cost_per_kwh | 388 | 455
Power capacity cost ($/kW) | ElectricStorage | installed_cost_per_kw | 775 | 910
Energy capacity replacement cost ($/kWh) | ElectricStorage | replace_cost_per_kwh | 220 | 318
Power capacity replacement cost ($/kW) | ElectricStorage | replace_cost_per_kw | 440 | 715
Fuel burn rate by generator capacity (gal/kWh) | Generator | fuel_slope_gal_per_kwh | 0.076 | removed and replaced   with full and half-load efficiencies
Electric efficiency at 100% load (% HHV-basis) | Generator | electric_efficiency_full_load | N/A - new input | 0.322
Electric efficiency at 50% load (% HHV-basis) | Generator | electric_efficiency_half_load | N/A - new input | 0.322
Generator fuel higher heating value (HHV) | Generator | fuel_higher_heating_value_kwh_per_gal | N/A - new input | 40.7
System capital cost     ($/kW) | Generator | installed_cost_per_kw | 500 | $650   if the generator only runs during outages;      $800 if it is allowed to run parallel with the grid;      $880 for off-grid
Fixed O&M     ($/kW/yr) | Generator | om_cost_per_kw | Grid   connected: 10      Off-grid: 20 | Grid   connected: 20      Off-grid: 10
System capital cost ($/kW) Class | Wind | size_class_to_installed_cost | residential   - 5675     commercial - 4300     medium - 2766     large - 2239 | residential   - 6339     commercial - 4760     medium - 3137     large - 2386
O&M cost ($/kW/year) | Wind | om_cost_per_kw | 35 | 36



</body>

</html>

