### PR TITLE
process is_electric_only in /chp_defaults endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
-## Develop 2023-10-11
+## Develop 2023-10-20
 ### Minor Updates
 ##### Changed
 - Updates to CHP cost and performance defaults, including prime generator, from updating REopt.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Classify the change according to the following categories:
 ## Develop 2023-10-11
 ### Minor Updates
 ##### Changed
-- Updates to CHP cost and performance defaults, from updating REopt.jl
+- Updates to CHP cost and performance defaults, including prime generator, from updating REopt.jl
 - Changed upper limit on `CHPInputs.size_class` to 7 to reflect changes in CHP defaults.
 
 ## v3.1.1

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -718,7 +718,7 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
 git-tree-sha1 = "b1c124786eeb42d84030d8fcd2224f2687465d9d"
-repo-rev = "chp-defaults-allow-electric-only-nothing"
+repo-rev = "develop"
 repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 version = "0.36.0"

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -717,8 +717,8 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "52bbf87ecb241c27d7283d38bde2a81ce5f22131"
-repo-rev = "develop"
+git-tree-sha1 = "b1c124786eeb42d84030d8fcd2224f2687465d9d"
+repo-rev = "chp-defaults-allow-electric-only-nothing"
 repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 version = "0.36.0"

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -220,7 +220,8 @@ function chp_defaults(req::HTTP.Request)
                 "avg_electric_load_kw",
                 "max_electric_load_kw"]
     int_vals = ["size_class"]
-    all_vals = vcat(string_vals, float_vals, int_vals)
+    bool_vals = ["is_electric_only"]
+    all_vals = vcat(string_vals, float_vals, int_vals, bool_vals)
     # Process .json inputs and convert to correct type if needed
     for k in all_vals
         if !haskey(d, k)
@@ -228,8 +229,10 @@ function chp_defaults(req::HTTP.Request)
         elseif !isnothing(d[k])
             if k in float_vals && typeof(d[k]) == String
                 d[k] = parse(Float64, d[k])
-            elseif k == int_vals && typeof(d[k]) == String
+            elseif k in int_vals && typeof(d[k]) == String
                 d[k] = parse(Int64, d[k])
+            elseif k in bool_vals && typeof(d[k]) == String
+                d[k] = parse(Bool, d[k])
             end
         end
     end

--- a/reoptjl/test/test_http_endpoints.py
+++ b/reoptjl/test/test_http_endpoints.py
@@ -35,6 +35,38 @@ class TestHTTPEndpoints(ResourceTestCaseMixin, TestCase):
         self.assertEqual(http_response["prime_mover"], "combustion_turbine")
         self.assertEqual(http_response["size_class"], 2)
         self.assertGreater(http_response["chp_elec_size_heuristic_kw"], 3500.0)
+        self.assertEqual(http_response["default_inputs"]["federal_itc_fraction"], 0.3)
+
+        inputs = {
+            "prime_mover": "micro_turbine",
+            "avg_electric_load_kw": 885.0247784246575,
+            "max_electric_load_kw": 1427.334,
+            "is_electric_only": "true"
+        }
+
+        # Direct call of the http.jl endpoint /chp_defaults
+        julia_host = os.environ.get('JULIA_HOST', "julia")
+        response = requests.get("http://" + julia_host + ":8081/chp_defaults/", json=inputs)
+        http_response = response.json()
+
+        # Check the endpoint logic with the expected selection
+        self.assertEqual(http_response["default_inputs"]["federal_itc_fraction"], 0.3)
+
+        inputs = {
+            "prime_mover": "combustion_turbine",
+            "size_class": 4,
+            "is_electric_only": "true",
+            "avg_electric_load_kw": 885.0247784246575,
+            "max_electric_load_kw": 1427.334
+            }
+
+        # Direct call of the http.jl endpoint /chp_defaults
+        julia_host = os.environ.get('JULIA_HOST', "julia")
+        response = requests.get("http://" + julia_host + ":8081/chp_defaults/", json=inputs)
+        http_response = response.json()
+
+        # Check the endpoint logic with the expected selection
+        self.assertEqual(http_response["default_inputs"]["federal_itc_fraction"], 0.0)
     
     def test_steamturbine_defaults(self):
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
fix handling of `is_electric_only` in the `/chp_defaults` endpoint to allow for prime generator inputs to be retrieved

