### PR TITLE
Fix chp defaults view

### DIFF
--- a/reoptjl/test/test_http_endpoints.py
+++ b/reoptjl/test/test_http_endpoints.py
@@ -67,6 +67,21 @@ class TestHTTPEndpoints(ResourceTestCaseMixin, TestCase):
 
         # Check the endpoint logic with the expected selection
         self.assertEqual(http_response["default_inputs"]["federal_itc_fraction"], 0.0)
+
+        inputs = {
+            "prime_mover": "recip_engine",
+            "size_class": 4,
+            "is_electric_only": "true",
+            "avg_electric_load_kw": 885.0247784246575,
+            "max_electric_load_kw": 1427.334
+            }
+
+        # Call to the django view endpoint /chp_defaults which calls the http.jl endpoint
+        resp = self.api_client.get(f'/v3/chp_defaults', data=inputs)
+        view_response = json.loads(resp.content)
+
+        # Check the endpoint logic with the expected selection
+        self.assertEqual(http_response["default_inputs"]["federal_itc_fraction"], 0.0)
     
     def test_steamturbine_defaults(self):
 

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -375,6 +375,7 @@ def chp_defaults(request):
         "boiler_efficiency": request.GET.get("boiler_efficiency"),
         "avg_electric_load_kw": request.GET.get("avg_electric_load_kw"),
         "max_electric_load_kw": request.GET.get("max_electric_load_kw"),
+        "is_electric_only": request.GET.get("is_electric_only")
     }
     if (request.GET.get("size_class")):
         inputs["size_class"] = int(request.GET.get("size_class"))


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Fixes bug in obtaining CHP defaults using django to call the endpoint instead of calling it directly.


### What is the current behavior?
parameter `is_electric_only` is not added to inputs when calling http.jl from django, leading to a default value of `"false"`



### What is the new behavior (if this is a feature change)?
`is_electric_only = "true"` is now appropriately received by the API, so Prime Generator technologies are created with appropriate adjustments to capital costs and tax incentives.



### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No


### Other information:
