### PR TITLE
No Min Turndown for CHP during outages

### DIFF
--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -729,11 +729,9 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "d78ad436fc1ef6c39e1346f1854d93fbbf465875"
-repo-rev = "develop"
-repo-url = "https://github.com/NREL/REopt.jl.git"
+git-tree-sha1 = "09bf72fce9a954f219e3ac3129ab83221fb21ff1"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.37.1"
+version = "0.37.2"
 
 [[deps.Random]]
 deps = ["SHA", "Serialization"]

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -729,7 +729,9 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "e0f05ebbc7a7c4e8117d03f6900d93aa310e9d81"
+git-tree-sha1 = "d78ad436fc1ef6c39e1346f1854d93fbbf465875"
+repo-rev = "develop"
+repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
 version = "0.37.1"
 


### PR DESCRIPTION
Consistent with V2, we do not want to enforce `min_turn_down_fraction` for `CHP` during multiple/stochastic outages