### PR TITLE
Ignore CHP unavailability during multiple outages

### DIFF
--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -729,9 +729,11 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "09bf72fce9a954f219e3ac3129ab83221fb21ff1"
+git-tree-sha1 = "a77b7a53b3b9f795228699c23bc76ec1d681f8a7"
+repo-rev = "chp-unavail-outages"
+repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.37.2"
+version = "0.37.1"
 
 [[deps.Random]]
 deps = ["SHA", "Serialization"]

--- a/reoptjl/test/test_job_endpoint.py
+++ b/reoptjl/test/test_job_endpoint.py
@@ -33,7 +33,7 @@ class TestJobEndpoint(ResourceTestCaseMixin, TransactionTestCase):
         self.assertAlmostEqual(sum(sum(np.array(results["Outages"]["unserved_load_per_outage_kwh"]))), 0.0, places=0)
         # TODO figure out why microgrid_upgrade_capital_cost is about $3000 different locally than on GitHub Actions
         self.assertAlmostEqual(results["Outages"]["microgrid_upgrade_capital_cost"], 1974429.4, delta=5000.0)
-        self.assertAlmostEqual(results["Financial"]["lcc"], 59868435.9, delta=5000.0)
+        self.assertAlmostEqual(results["Financial"]["lcc"], 59907198.3, places=-4)
 
     def test_pv_battery_and_emissions_defaults_from_julia(self):
         """


### PR DESCRIPTION
Currently, inconsistent with the deterministic single outage scenario which ignores CHP unavailability during the outage, the stochastic multiple outages was not ignoring CHP unavailability. This PR changes that to ignore CHP unavailability during the outages, while preserving the unavailability periods for the 8760 grid-tied operation. This allows consistency in the economic dispatch between non-outages and outages scenarios.