### PR TITLE
Hot Fix: add year for electric-only CHP unavailability profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The REopt Julia package will soon become the backend of the REopt API. That mean
 - You do not want to modify the code or host the API on your own server. 
 - You do not want to install or use your own optimization solver (simply POSTing to the REopt API does not require a solver, whereas using the Julia package does).
 - You want to be able to access or share results saved in a database using a runuuid.
-- You want to be able to view your API results in the REopt web tool using a runuuid. (we can do this?)
-- **How do I use the REopt API?:** you can access our production version of the API via the [NREL Developer Network](https://developer.nrel.gov/docs/energy-optimization/reopt/). You can view examples of using the API in the [REopt-API-Analysis Repo](https://github.com/NREL/REopt-API-Analysis/wiki).
+- **How do I use the REopt API?:** you can access our production version of the API via the [NREL Developer Network](https://developer.nrel.gov/docs/energy-optimization/reopt/). You can view examples of using the API in the [REopt-Analysis-Scripts Repo](https://github.com/NREL/REopt-Analysis-Scripts/wiki).
 
 **4. When and how to _modify_ the REopt_API:**
 - You have made changes to the REopt Julia package that include modified inputs or outputs, and want to reflect those in the REopt API.

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -729,9 +729,9 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "60798d610ebe263fb12bd83437309c39443c39bf"
+git-tree-sha1 = "6f3db36b83c7a3f8aa8d3ab187b91a5a6ac159cb"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.37.3"
+version = "0.37.4"
 
 [[deps.Random]]
 deps = ["SHA", "Serialization"]

--- a/reoptjl/api.py
+++ b/reoptjl/api.py
@@ -96,7 +96,7 @@ class Job(ModelResource):
         meta = {
             "run_uuid": run_uuid,
             "api_version": 3,
-            "reopt_version": "0.37.3",
+            "reopt_version": "0.37.4",
             "status": "Validating..."
         }
         bundle.data.update({"APIMeta": meta})

--- a/reoptjl/test/test_job_endpoint.py
+++ b/reoptjl/test/test_job_endpoint.py
@@ -33,7 +33,7 @@ class TestJobEndpoint(ResourceTestCaseMixin, TransactionTestCase):
         self.assertAlmostEqual(sum(sum(np.array(results["Outages"]["unserved_load_per_outage_kwh"]))), 0.0, places=0)
         # TODO figure out why microgrid_upgrade_capital_cost is about $3000 different locally than on GitHub Actions
         self.assertAlmostEqual(results["Outages"]["microgrid_upgrade_capital_cost"], 1974429.4, delta=5000.0)
-        self.assertAlmostEqual(results["Financial"]["lcc"], 59907198.3, places=-4)
+        self.assertAlmostEqual(results["Financial"]["lcc"], 59865240.0, delta=5000.0)
 
     def test_pv_battery_and_emissions_defaults_from_julia(self):
         """


### PR DESCRIPTION
This fixes a discrepancy between the load profile and the year used for the CHP unavailability -> production factor, for electric-only CHP (Prime Generator)