### PR TITLE
allow international wind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ Classify the change according to the following categories:
     ### Patches
 
 
+## Develop - 2024-01-30
+### Minor Updates
+#### Fixed
+- Fixed Wind validation code to prevent erroring when user provides `production_factor_series` for location outside of WindToolkit bounds. 
+#### Changed
+- Updated `reopt_version` in `ERPJob` to 0.39.1
+ 
 ## v3.4.0
 ### Minor Updates
 #### Added 

--- a/reoptjl/validators.py
+++ b/reoptjl/validators.py
@@ -288,7 +288,7 @@ class InputValidator(object):
                 for time_series in ["production_factor_series"] + wind_resource_inputs:
                     self.clean_time_series("Wind", time_series)
 
-                if not all([self.models["Wind"].__getattribute__(wr) for wr in wind_resource_inputs]):
+                if not all([self.models["Wind"].__getattribute__(wr) for wr in wind_resource_inputs]) and not self.models["Wind"].__getattribute__("production_factor_series"):
                     # then no wind_resource_inputs provided, so we need to get the resource from WindToolkit
                     if not lat_lon_in_windtoolkit(self.models["Site"].__getattribute__("latitude"),
                                                   self.models["Site"].__getattribute__("longitude")):
@@ -663,5 +663,5 @@ def lat_lon_in_windtoolkit(lat, lon):
     y = int(round((point[1] - origin[1]) / 2000))
     y_max, x_max = (1602, 2976)
     if (x < 0) or (y < 0) or (x >= x_max) or (y >= y_max):
-        raise ValueError("Latitude/Longitude is outside of wind resource dataset bounds.")
+        return None
     return y, x

--- a/resilience_stats/api.py
+++ b/resilience_stats/api.py
@@ -62,7 +62,7 @@ class ERPJob(ModelResource):
 
         meta_dict = {
             "run_uuid": erp_run_uuid,
-            "reopt_version": "0.30.0",
+            "reopt_version": "0.39.1",
             "status": "Validating..."
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
You previously could not run a Wind eval for a location outside of the WindToolkit bounds (e.g. international locations), due to the Wind validation code.  This PR fixes this. 

### Other information:
- I also updated the REopt.jl version in the meta data of the ERP code 