### PR TITLE
ERP bug fix: divide by zero BESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop
+### Minor Updates
+#### Fixed
+- Fixed divide by zero error when POSTing to the `/erp` endpoint with a `battery_size_kw` of 0
 
 ## v3.4.1
 ### Minor Updates

--- a/resilience_stats/models.py
+++ b/resilience_stats/models.py
@@ -423,7 +423,10 @@ class ERPElectricStorageInputs(BaseModel, models.Model):
 
     def clean(self):
         if self.num_battery_bins is None:
-            self.num_battery_bins = round(20 * self.size_kwh / self.size_kw)
+            if self.size_kw == 0:
+                self.num_battery_bins = 1
+            else:
+                self.num_battery_bins = round(20 * self.size_kwh / self.size_kw)
 
 
 class ERPPVInputs(BaseModel, models.Model):

--- a/resilience_stats/tests/test_erp.py
+++ b/resilience_stats/tests/test_erp.py
@@ -47,7 +47,7 @@ class ERPTests(ResourceTestCaseMixin, TestCase):
             self.reopt_base_erp_chp_defaults.format(prime_mover, is_chp, size_kw),
             format='json'
         )
-
+        
     def test_erp_long_duration_battery(self):
         post_opt = json.load(open(self.post_opt_long_dur_stor, 'rb'))
         resp = self.get_response_opt(post_opt)
@@ -171,7 +171,17 @@ class ERPTests(ResourceTestCaseMixin, TestCase):
         results = json.loads(resp.content)
 
         self.assertAlmostEqual(results["outputs"]["mean_cumulative_survival_final_time_step"], 0.904242, places=4) #0.990784, places=4)
-    
+
+        # Test that zero battery doesn't cause error
+        post_sim["ElectricStorage"]["size_kwh"] = 0
+        post_sim["ElectricStorage"]["size_kwh"] = 0
+        resp = self.get_response_sim(post_sim)
+        self.assertHttpCreated(resp)
+        r_sim = json.loads(resp.content)
+        erp_run_uuid = r_sim.get('run_uuid')
+        resp = self.get_results_sim(erp_run_uuid)
+        self.assertHttpOK(resp)
+
     def test_erp_help_view(self):
         """
         Tests hiting the erp/help url to get defaults and other info about inputs


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
Bug fix

### What is the current behavior?
Divide by zero error when POSTing to the `/erp` endpoint with a `battery_size_kw` of 0

### What is the new behavior (if this is a feature change)?
When `battery_size_kw` is 0, the `num_battery_bins` default is 1

### Does this PR introduce a breaking change?
No

### Other information:
