### PR TITLE
REopt.jl v0.43.0

### DIFF
--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -841,11 +841,9 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "4e76a49a93204840c1dd783a982e612525b6330c"
-repo-rev = "steamturb-simload"
-repo-url = "https://github.com/NREL/REopt.jl.git"
+git-tree-sha1 = "d7bdc0d314e0821a8904ba204265345aab1ee8bc"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.42.0"
+version = "0.43.0"
 
 [[deps.Random]]
 deps = ["SHA", "Serialization"]

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -841,9 +841,11 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "81145461bcc15162ef468858d62b41357bb13684"
+git-tree-sha1 = "0232669d3ee7afe8e3eac0e3f3a97d8ed790321f"
+repo-rev = "steamturb-simload"
+repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.41.0"
+version = "0.42.0"
 
 [[deps.Random]]
 deps = ["SHA", "Serialization"]

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -841,7 +841,7 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "0232669d3ee7afe8e3eac0e3f3a97d8ed790321f"
+git-tree-sha1 = "4e76a49a93204840c1dd783a982e612525b6330c"
 repo-rev = "steamturb-simload"
 repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"

--- a/reoptjl/api.py
+++ b/reoptjl/api.py
@@ -98,7 +98,7 @@ class Job(ModelResource):
         meta = {
             "run_uuid": run_uuid,
             "api_version": 3,
-            "reopt_version": "0.41.0",
+            "reopt_version": "0.43.0",
             "status": "Validating..."
         }
         bundle.data.update({"APIMeta": meta})

--- a/reoptjl/test/test_http_endpoints.py
+++ b/reoptjl/test/test_http_endpoints.py
@@ -109,7 +109,7 @@ class TestHTTPEndpoints(ResourceTestCaseMixin, TestCase):
         # Check the endpoint logic with the expected selection
         self.assertEqual(http_response["prime_mover"], "steam_turbine")
         self.assertEqual(http_response["size_class"], 1)
-        self.assertGreater(http_response["chp_size_based_on_avg_heating_load_kw"], 574.419)
+        self.assertGreater(http_response["chp_elec_size_heuristic_kw"], 574.419)
 
     def test_absorption_chiller_defaults(self):
 


### PR DESCRIPTION
See PR's from REopt.jl here:

https://github.com/NREL/REopt.jl/pull/364

From REopt.jl CHANGELOG:
## v0.43.0
### Fixed
- `simple_payback_years` calculation when there is export credit
- Issue with `SteamTurbine` heuristic size and default calculation when `size_class` was input
- BAU emissions calculation with heating load which was using thermal instead of fuel

