### PR TITLE
Big M Constraint Updates, addition to /chp_defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop 2024-07-08
+#### Added
+- Added attribute `thermal_efficiency` to the arguments of http endpoint `chp_defaults`
+#### Fixed
+- See fixes and changes here: https://github.com/NREL/REopt.jl/releases/tag/v0.47.2
+
 ## v3.9.1
 ### Minor Updates
 #### Added

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -917,9 +917,11 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "b51d56a6398f302100004184b64bbe3d1e137277"
+git-tree-sha1 = "f4a44705bd9038f920be6998ec553897c09eb5d5"
+repo-rev = "mt-therm-effic"
+repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.47.1"
+version = "0.47.0"
 
 [[deps.Random]]
 deps = ["SHA"]

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -917,11 +917,9 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "f4a44705bd9038f920be6998ec553897c09eb5d5"
-repo-rev = "mt-therm-effic"
-repo-url = "https://github.com/NREL/REopt.jl.git"
+git-tree-sha1 = "c02ff7c0b60352164b89f39789424422083ae4eb"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.47.0"
+version = "0.47.2"
 
 [[deps.Random]]
 deps = ["SHA"]

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -199,7 +199,8 @@ function chp_defaults(req::HTTP.Request)
     float_vals = ["avg_boiler_fuel_load_mmbtu_per_hour",
                 "boiler_efficiency",
                 "avg_electric_load_kw",
-                "max_electric_load_kw"]
+                "max_electric_load_kw",
+                "thermal_efficiency"]
     int_vals = ["size_class"]
     bool_vals = ["is_electric_only"]
     all_vals = vcat(string_vals, float_vals, int_vals, bool_vals)

--- a/julia_src/http.jl
+++ b/julia_src/http.jl
@@ -207,7 +207,9 @@ function chp_defaults(req::HTTP.Request)
     # Process .json inputs and convert to correct type if needed
     for k in all_vals
         if !haskey(d, k)
-            d[k] = nothing
+            if !(k == "thermal_efficiency")  # thermal_efficiency is of type Float64 (incl NaN), so it can't be "nothing"
+                d[k] = nothing
+            end
         elseif !isnothing(d[k])
             if k in float_vals && typeof(d[k]) == String
                 d[k] = parse(Float64, d[k])

--- a/reoptjl/api.py
+++ b/reoptjl/api.py
@@ -98,7 +98,7 @@ class Job(ModelResource):
         meta = {
             "run_uuid": run_uuid,
             "api_version": 3,
-            "reopt_version": "0.47.1",
+            "reopt_version": "0.47.2",
             "status": "Validating..."
         }
         bundle.data.update({"APIMeta": meta})

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -381,11 +381,15 @@ def chp_defaults(request):
         "boiler_efficiency": request.GET.get("boiler_efficiency"),
         "avg_electric_load_kw": request.GET.get("avg_electric_load_kw"),
         "max_electric_load_kw": request.GET.get("max_electric_load_kw"),
-        "is_electric_only": request.GET.get("is_electric_only"),
-        "thermal_efficiency": request.GET.get("thermal_efficiency")
+        "is_electric_only": request.GET.get("is_electric_only")
     }
-    if (request.GET.get("size_class")):
-        inputs["size_class"] = int(request.GET.get("size_class"))
+
+    if request.GET.get("size_class"):
+        inputs["size_class"] = int(request.GET.get("size_class"))  # Not sure if this is necessary because we convert to int in http.jl
+
+    if request.GET.get("thermal_efficiency"):
+        inputs["thermal_efficiency"] = request.GET.get("thermal_efficiency")  # Conversion to correct type happens in http.jl
+
     try:
         julia_host = os.environ.get('JULIA_HOST', "julia")
         http_jl_response = requests.get("http://" + julia_host + ":8081/chp_defaults/", json=inputs)

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -381,7 +381,8 @@ def chp_defaults(request):
         "boiler_efficiency": request.GET.get("boiler_efficiency"),
         "avg_electric_load_kw": request.GET.get("avg_electric_load_kw"),
         "max_electric_load_kw": request.GET.get("max_electric_load_kw"),
-        "is_electric_only": request.GET.get("is_electric_only")
+        "is_electric_only": request.GET.get("is_electric_only"),
+        "thermal_efficiency": request.GET.get("thermal_efficiency")
     }
     if (request.GET.get("size_class")):
         inputs["size_class"] = int(request.GET.get("size_class"))


### PR DESCRIPTION
- Update Big M constraints to address bugs after indicator -> Big M conversions
  - https://github.com/NREL/REopt.jl/pull/401 
- Add `thermal_efficiency` as input to /chp_defaults endpoint to handle custom CHP prime movers which cannot normally supply steam
  - https://github.com/NREL/REopt.jl/pull/415

