### PR TITLE
fix to correct results link in results table

### DIFF
--- a/reoptjl/custom_table_config.py
+++ b/reoptjl/custom_table_config.py
@@ -137,8 +137,8 @@ custom_table_webtool = [
     {
         "label"         : "Results URL",
         "key"           : "url",
-        "bau_value"     : lambda df: f'=HYPERLINK("https://custom-table-download-reopt-stage.its.nrel.gov/tool/results/{safe_get(df, "webtool_uuid")}", "Results Link")',
-        "scenario_value": lambda df: f'=HYPERLINK("https://custom-table-download-reopt-stage.its.nrel.gov/tool/results/{safe_get(df, "webtool_uuid")}", "Results Link")'
+        "bau_value"     : lambda df: f'=HYPERLINK("https://reopt.nrel.gov/tool/results/{safe_get(df, "webtool_uuid")}", "Results Link")',
+        "scenario_value": lambda df: f'=HYPERLINK("https://reopt.nrel.gov/tool/results/{safe_get(df, "webtool_uuid")}", "Results Link")'
     },
     #####################################################################################################
     ######################### System Capacities #############################


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] CHANGELOG.md is updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Bug fix for results table links


### What is the current behavior?
(You can also link to an open issue here)
The current link points to the staged url that was previously used for testing


### What is the new behavior (if this is a feature change)?
The fix will redirect the results link to the live reopt version


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No changes will be necessary, although users may need to re-download the results table


### Other information:
