### PR TITLE
Return multiple summary focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## Develop - 2024-10-24
+### Minor Updates
+##### Changed
+- Summary focus can now be a string with multiple types of focus such as `A,B,C`
+
 ## v3.10.1
 ### Minor Updates
 ##### Fixed

--- a/reoptjl/views.py
+++ b/reoptjl/views.py
@@ -1066,17 +1066,17 @@ def queryset_for_summary(api_metas,summary_dict:dict):
     )
     if len(utility) > 0:
         for m in utility:
-
+            summary_dict[str(m.meta.run_uuid)]['focus'] = ''
             if m.outage_start_time_step is None:
                 if len(m.outage_start_time_steps) == 0:
-                    summary_dict[str(m.meta.run_uuid)]['focus'] = "Financial"
+                    summary_dict[str(m.meta.run_uuid)]['focus'] += "Financial,"
                 else:
-                    summary_dict[str(m.meta.run_uuid)]['focus'] = "Resilience"
+                    summary_dict[str(m.meta.run_uuid)]['focus'] += "Resilience,"
                     summary_dict[str(m.meta.run_uuid)]['outage_duration'] = m.outage_durations[0] # all durations are same.
             else:
                 # outage start timestep was provided, is 1 or more
                 summary_dict[str(m.meta.run_uuid)]['outage_duration'] = m.outage_end_time_step - m.outage_start_time_step + 1
-                summary_dict[str(m.meta.run_uuid)]['focus'] = "Resilience"
+                summary_dict[str(m.meta.run_uuid)]['focus'] += "Resilience,"
     
     site = SiteOutputs.objects.filter(meta__run_uuid__in=run_uuids).only(
         'meta__run_uuid',
@@ -1099,13 +1099,13 @@ def queryset_for_summary(api_metas,summary_dict:dict):
         for m in site_inputs:
             try: # can be NoneType
                 if m.renewable_electricity_min_fraction > 0:
-                    summary_dict[str(m.meta.run_uuid)]['focus'] = "Clean-energy"
+                    summary_dict[str(m.meta.run_uuid)]['focus'] += "Clean-energy,"
             except:
                 pass # is NoneType
 
             try: # can be NoneType
                 if m.renewable_electricity_max_fraction > 0:
-                    summary_dict[str(m.meta.run_uuid)]['focus'] = "Clean-energy"
+                    summary_dict[str(m.meta.run_uuid)]['focus'] += "Clean-energy,"
             except:
                 pass # is NoneType
 
@@ -1119,10 +1119,10 @@ def queryset_for_summary(api_metas,summary_dict:dict):
     if len(settings) > 0:
         for m in settings:
             if m.off_grid_flag:
-                summary_dict[str(m.meta.run_uuid)]['focus'] = "Off-grid"
+                summary_dict[str(m.meta.run_uuid)]['focus'] += "Off-grid,"
             
             if m.include_climate_in_objective or m.include_health_in_objective:
-                summary_dict[str(m.meta.run_uuid)]['focus'] = "Clean-energy"
+                summary_dict[str(m.meta.run_uuid)]['focus'] += "Clean-energy,"
 
     tariffInputs = ElectricTariffInputs.objects.filter(meta__run_uuid__in=run_uuids).only(
         'meta__run_uuid',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] CHANGELOG.md is updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce?
(Bug fix, feature, docs update, ...)
Feature


### What is the current behavior?
(You can also link to an open issue here)
A summary run can only have 1 focus (i.e. resilience or financial or clean-energy)


### What is the new behavior (if this is a feature change)?
A summary can have all applicable focuses.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)
No.


### Other information:
