### PR TITLE
Fix updating CHP.installed_cost_per_kw if scalar

### DIFF
--- a/reoptjl/src/process_results.py
+++ b/reoptjl/src/process_results.py
@@ -126,6 +126,8 @@ def update_inputs_in_database(inputs_to_update: dict, run_uuid: str) -> None:
             SiteInputs.objects.filter(meta__run_uuid=run_uuid).update(**inputs_to_update["Site"])
 
         if inputs_to_update["CHP"]:  # Will be an empty dictionary if CHP is not considered
+            if inputs_to_update["CHP"].get("installed_cost_per_kw") and type(inputs_to_update["CHP"].get("installed_cost_per_kw")) == float:
+                inputs_to_update["CHP"]["installed_cost_per_kw"] = [inputs_to_update["CHP"]["installed_cost_per_kw"]]
             CHPInputs.objects.filter(meta__run_uuid=run_uuid).update(**inputs_to_update["CHP"])
         if inputs_to_update["SteamTurbine"]:  # Will be an empty dictionary if SteamTurbine is not considered
             SteamTurbineInputs.objects.filter(meta__run_uuid=run_uuid).update(**inputs_to_update["SteamTurbine"])


### PR DESCRIPTION
- Fix issue with CHP.installed_cost_per_kw not being an array when updating the inputs model object (which expects an array) in process_results.py, from Julia.
- For context, we rely on REopt.jl logic to assign CHP defaults, and then we have to update the API model fields after REopt.jl runs, in process_results.py. Since CHP.installed_cost_per_kw can be either a float or an array in REopt.jl, while in the API model field it's processed to always be an array, we need to check and convert to an array if it comes back from REopt.jl as a float.