### PR TITLE
Fix updating ASHP Inputs defaults from REopt.jl

### DIFF
--- a/reoptjl/test/posts/ashp_defaults_update.json
+++ b/reoptjl/test/posts/ashp_defaults_update.json
@@ -1,0 +1,51 @@
+{
+    "user_uuid": "1d2ef71e-fd93-4c4a-b5c3-1485a87f772e",
+    "webtool_uuid": "1ab7530f-74b8-4ea8-b8ed-f11bd953f61f",
+    "Settings": {
+        "optimality_tolerance": 0.001,
+        "solver_name": "HiGHS",
+        "off_grid_flag": false,
+        "include_climate_in_objective": false,
+        "include_health_in_objective": false
+    },
+    "Meta": {
+        "address": "San Francisco CA USA"
+    },
+    "Site": {
+        "latitude": 37.7749295,
+        "longitude": -122.4194155,
+        "include_exported_renewable_electricity_in_total": true,
+        "include_exported_elec_emissions_in_total": true,
+        "land_acres": 1000000.0,
+        "roof_squarefeet": 0
+    },
+    "ElectricLoad": {
+        "doe_reference_name": "Hospital"
+    },
+    "ElectricTariff": {
+        "blended_annual_energy_rate": 0.15,
+        "blended_annual_demand_rate": 0.0
+    },
+    "ElectricUtility": {
+        "cambium_location_type": "GEA Regions",
+        "cambium_metric_col": "lrmer_co2e",
+        "cambium_scenario": "Mid-case",
+        "cambium_grid_level": "enduse"
+    },
+    "SpaceHeatingLoad": {
+        "annual_mmbtu": 11570.916,
+        "doe_reference_name": "Hospital"
+    },
+    "DomesticHotWaterLoad": {
+        "annual_mmbtu": 671.405,
+        "doe_reference_name": "Hospital"
+    },
+    "ExistingBoiler": {
+        "fuel_type": "natural_gas",
+        "fuel_cost_per_mmbtu": 25.0
+    },
+    "ASHPSpaceHeater": {
+        "force_into_system": true,
+        "can_serve_cooling": false
+    }
+}

--- a/reoptjl/test/test_job_endpoint.py
+++ b/reoptjl/test/test_job_endpoint.py
@@ -312,3 +312,18 @@ class TestJobEndpoint(ResourceTestCaseMixin, TransactionTestCase):
         r = json.loads(resp.content)
 
         self.assertAlmostEqual(r["outputs"]["Financial"]["lifecycle_capital_costs"], 1046066.8, delta=1000)
+
+    def test_ashp_defaults_update_from_julia(self):
+        # Test that the inputs_with_defaults_set_in_julia feature worked for ASHPSpaceHeater
+        post_file = os.path.join('reoptjl', 'test', 'posts', 'ashp_defaults_update.json')
+        post = json.load(open(post_file, 'r'))
+        resp = self.api_client.post('/stable/job/', format='json', data=post)
+        self.assertHttpCreated(resp)
+        r = json.loads(resp.content)
+        run_uuid = r.get('run_uuid')
+
+        resp = self.api_client.get(f'/stable/job/{run_uuid}/results')
+        r = json.loads(resp.content)
+        
+        self.assertEquals(r["inputs"]["ASHPSpaceHeater"]["om_cost_per_ton"], 0.0)
+        self.assertEquals(r["inputs"]["ASHPSpaceHeater"]["sizing_factor"], 1.1)        


### PR DESCRIPTION
- There were extra input fields coming back from REopt.jl for ASHP defaults (fields that were not included in the API, such as `can_serve_process_heat`) and trying to update the Django models for ASHP Inputs with those, and that was causing the update to error silently (within a try except clause)
- This PR prunes any of those extra fields that are not included in the Django model classes before updating the models