### PR TITLE
Fix for user-input wind installed cost to not be over-written

### DIFF
--- a/reoptjl/models.py
+++ b/reoptjl/models.py
@@ -3213,7 +3213,7 @@ class WindInputs(BaseModel, models.Model):
     )
 
     def clean(self):
-        if self.size_class != "":
+        if self.size_class != "" and self.installed_cost_per_kw is None:
             self.installed_cost_per_kw = WIND_COST_DEFAULTS.get(self.size_class, None) # will get set in REopt.jl if size_class not supplied
 
 class WindOutputs(BaseModel, models.Model):


### PR DESCRIPTION
_Current_:
If a user inputs an `installed_cost_per_kw` for `Wind`, along with a `Wind.size_class`, the `installed_cost_per_kw` value gets overwritten by the default cost value for the `size_class`. The web tool always sends a `size_class`, so currently web tool users **cannot provide a custom input wind installed cost**. 

_Fix_:
This PR fixes this to pass the user-input `installed_cost_per_kw`.